### PR TITLE
Re-enables jacoco coverage report (#62)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run tests
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: test --stacktrace --info
+          arguments: jacocoTestReport --stacktrace --info
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       ##
@@ -69,3 +69,10 @@ jobs:
         with:
           name: test-report-${{ matrix.os }}
           path: build/reports/tests/test
+
+      - name: Upload HTML test coverage report
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: build/reports/jacoco/test/html

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,14 +80,17 @@ tasks {
         dependsOn(test)
 
         reports {
+            html.required.set(true)
             xml.required.set(true)
         }
+
+        classDirectories.setFrom("build/classes/java/main")
     }
 }
 
 /* SonarCloud */
 tasks.sonarqube {
-    dependsOn(tasks.build)
+    dependsOn(tasks.build, tasks.jacocoTestReport)
 
     sonarqube {
         properties {


### PR DESCRIPTION
I believe JetBrains changed something about their compile steps causing jacoco to find multiple versions of compiled classes in different directories.
Explicitly setting the class directory to use fixes the issues we had in #59