### PR TITLE
Re-enable test coverage report

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run tests
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: test --stacktrace --info
+          arguments: test --stacktrace --info jacocoTestReport
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       - name: Upload Test Report
@@ -37,3 +37,10 @@ jobs:
         with:
           name: test-report-${{ matrix.os }}
           path: build/reports/tests/test
+
+      - name: Upload HTML test coverage report
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: build/reports/jacoco/test/html

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.intellij.tasks.ListProductsReleasesTask
 
 plugins {
     id("org.jetbrains.changelog") version "1.3.1"
-    id("org.jetbrains.intellij") version "1.7.0"
+    id("org.jetbrains.intellij") version "1.8.0"
     java
 
     id("org.sonarqube") version "3.4.0.2513"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,7 +90,7 @@ tasks {
 
 /* SonarCloud */
 tasks.sonarqube {
-    dependsOn(tasks.build)
+    dependsOn(tasks.build, tasks.jacocoTestReport)
 
     sonarqube {
         properties {


### PR DESCRIPTION
Closes #62
This PR's HEAD is based on #93

SonarCloud Coverage acutally works but the message it left in this PR says No Coverage Information because `main` currently has none. Their Website actually shows
> 35.3% Estimated after merge

## ToDo
* [x] Merge #93 (or this one and close it instead)
* [x] ~~JaCoCo Coverage report is working again with the JetBrain's new plugin update but SonarCloud is still showing 'No Coverage~~