### PR TITLE
Fix mariadb specific dsn type

### DIFF
--- a/src/main/java/de/php_perfect/intellij/ddev/database/DataSourceProviderImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/database/DataSourceProviderImpl.java
@@ -12,6 +12,8 @@ import org.jetbrains.annotations.Nullable;
 
 public final class DataSourceProviderImpl implements DataSourceProvider {
 
+    public static final String DSN_HOST = "127.0.0.1";
+
     public @Nullable LocalDataSource buildDdevDataSource(@NotNull DatabaseInfo databaseInfo) {
         final DatabaseInfo.Type databaseType = databaseInfo.getType();
         if (databaseType == null) {
@@ -67,13 +69,29 @@ public final class DataSourceProviderImpl implements DataSourceProvider {
     }
 
     private @NotNull String getDsnByDatabaseType(@NotNull DatabaseInfo databaseInfo) {
-        String dsnType = "mysql";
-        String host = "127.0.0.1";
+        return String.format(
+                "jdbc:%s://%s:%d/%s?user=%s&password=%s",
+                getDsnType(databaseInfo.getType()),
+                DSN_HOST,
+                databaseInfo.getPublishedPort(),
+                databaseInfo.getName(),
+                databaseInfo.getUsername(),
+                databaseInfo.getPassword()
+        );
+    }
 
-        if (databaseInfo.getType() == DatabaseInfo.Type.POSTGRESQL) {
-            dsnType = "postgresql";
+    private static @NotNull String getDsnType(@Nullable DatabaseInfo.Type databaseType) {
+        if (databaseType == null) {
+            return "mysql";
         }
 
-        return String.format("jdbc:%s://%s:%d/%s?user=%s&password=%s", dsnType, host, databaseInfo.getPublishedPort(), databaseInfo.getName(), databaseInfo.getUsername(), databaseInfo.getPassword());
+        switch (databaseType) {
+            case POSTGRESQL:
+                return "postgresql";
+            case MARIADB:
+                return "mariadb";
+            default:
+                return "mysql";
+        }
     }
 }

--- a/src/test/java/de/php_perfect/intellij/ddev/database/DataSourceProviderTest.java
+++ b/src/test/java/de/php_perfect/intellij/ddev/database/DataSourceProviderTest.java
@@ -27,6 +27,18 @@ final class DataSourceProviderTest extends BasePlatformTestCase {
     }
 
     @Test
+    void mariaDb() {
+        DatabaseInfo databaseInfo = new DatabaseInfo(DatabaseInfo.Type.MARIADB, "10.4", 533, "", "some-internal-host", "some-user", "some-password", 12345);
+
+        DataSourceProviderImpl dataSourceProvider = new DataSourceProviderImpl();
+
+        LocalDataSource dataSource = dataSourceProvider.buildDdevDataSource(databaseInfo);
+        Assertions.assertInstanceOf(LocalDataSource.class, dataSource);
+        Assertions.assertNotNull(dataSource);
+        Assertions.assertEquals("jdbc:mariadb://127.0.0.1:12345/?user=some-user&password=some-password", dataSource.getUrl());
+    }
+
+    @Test
     void postgreSql() {
         DatabaseInfo databaseInfo = new DatabaseInfo(DatabaseInfo.Type.POSTGRESQL, "8.0", 533, "", "some-internal-host", "some-user", "some-password", 12345);
 


### PR DESCRIPTION
## The Problem/Issue/Bug:

* #106

## How this PR Solves the Problem:

When using maridb as database the dsn will now be jdbc:mariadb instead of jdbc:mysql as described in
 https://mariadb.com/kb/en/about-mariadb-connector-j/#jdbcmysql-scheme-compatibility