### PR TITLE
Fix failing unit tests by adding `junit-platform-launcher` as dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-params:$junitVersion")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.9.1")
     testImplementation("org.mockito:mockito-core:4.9.0")
     testImplementation("org.assertj:assertj-core:3.23.1")
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:
Test run locally or in GitHub Actions fail with an error/exception.

## How this PR Solves the Problem:
This PR adds `org.junit.platform:junit-platform-launcher` as a `testRuntimeOnly`-dependency fixing a `NoClassDefFoundError` that occurs when trying to run the tests

## Manual Testing Instructions:
Run `./gradlew test --stacktrace --info jacocoTestReport`

## Related Issue Link(s):
\-