### PR TITLE
GitHub Actions: Upload test reports even when tests fail

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,13 +33,14 @@ jobs:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       - name: Upload Test Report
+        if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
           name: test-report-${{ matrix.os }}
           path: build/reports/tests/test
 
       - name: Upload HTML test coverage report
-        if: matrix.os == 'ubuntu-latest'
+        if: ${{ matrix.os == 'ubuntu-latest' && always() }}
         uses: actions/upload-artifact@v3
         with:
           name: coverage-report


### PR DESCRIPTION
## The Problem/Issue/Bug:
The upload steps are skipped if the tests fail.
This should obviously not happen because reports get especially interesting with test failures.

## How this PR Solves the Problem:
By using `always()` ([docs](https://docs.github.com/en/actions/learn-github-actions/expressions#always)) as a step's run condition, we can ensure that it is run even on test failures.

## Manual Testing Instructions:
1. Have failing tests in the pipeline
2. Check if test reports get uploaded as artifacts anyway
3. Check if coverage report is still only being uploaded for Ubuntu/Linux

## Related Issue Link(s):
\-