### PR TITLE
Update ddev version check for better performance

### DIFF
--- a/src/main/java/de/php_perfect/intellij/ddev/cmd/Ddev.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/cmd/Ddev.java
@@ -2,10 +2,13 @@ package de.php_perfect.intellij.ddev.cmd;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
+import de.php_perfect.intellij.ddev.version.Version;
 import org.jetbrains.annotations.NotNull;
 
 public interface Ddev {
-    @NotNull Versions version(@NotNull String binary, @NotNull Project project) throws CommandFailedException;
+    @NotNull Version version(@NotNull String binary, @NotNull Project project) throws CommandFailedException;
+
+    @NotNull Versions detailedVersions(@NotNull String binary, @NotNull Project project) throws CommandFailedException;
 
     @NotNull Description describe(@NotNull String binary, @NotNull Project project) throws CommandFailedException;
 

--- a/src/main/java/de/php_perfect/intellij/ddev/cmd/DdevImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/cmd/DdevImpl.java
@@ -6,20 +6,56 @@ import com.intellij.execution.process.ProcessOutput;
 import com.intellij.openapi.project.Project;
 import de.php_perfect.intellij.ddev.cmd.parser.JsonParser;
 import de.php_perfect.intellij.ddev.cmd.parser.JsonParserException;
+import de.php_perfect.intellij.ddev.version.Version;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Type;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public final class DdevImpl implements Ddev {
     private static final int COMMAND_TIMEOUT = 8_000;
 
-    public @NotNull Versions version(final @NotNull String binary, final @NotNull Project project) throws CommandFailedException {
+    @Override
+    public @NotNull Version version(@NotNull String binary, @NotNull Project project) throws CommandFailedException {
+        final String versionString = this.executePlain(binary, "--version", project);
+        final Pattern r = Pattern.compile("ddev version (v.*)$");
+        final Matcher m = r.matcher(versionString);
+
+        if (m.find()) {
+            return new Version(m.group(1));
+        }
+
+        throw new CommandFailedException("Unexpcted output of ddev version command: " + versionString);
+    }
+
+    public @NotNull Versions detailedVersions(final @NotNull String binary, final @NotNull Project project) throws CommandFailedException {
         return execute(binary, "version", Versions.class, project);
     }
 
     public @NotNull Description describe(final @NotNull String binary, final @NotNull Project project) throws CommandFailedException {
         return execute(binary, "describe", Description.class, project);
+    }
+
+    private @NotNull String executePlain(final @NotNull String binary, final @NotNull String action, final @NotNull Project project) throws CommandFailedException {
+        final GeneralCommandLine commandLine = createDdevCommandLine(binary, action, project);
+
+        try {
+            final ProcessOutput processOutput = ProcessExecutor.getInstance().executeCommandLine(commandLine, COMMAND_TIMEOUT, false);
+
+            if (processOutput.isTimeout()) {
+                throw new CommandFailedException("Command timed out after " + (COMMAND_TIMEOUT / 1000) + " seconds: " + commandLine.getCommandLineString() + " in " + commandLine.getWorkDirectory().getPath());
+            }
+
+            if (processOutput.getExitCode() != 0) {
+                throw new CommandFailedException("Command '" + commandLine.getCommandLineString() + "' returned non zero exit code " + processOutput);
+            }
+
+            return processOutput.getStdout();
+        } catch (ExecutionException exception) {
+            throw new CommandFailedException("Failed to execute " + commandLine.getCommandLineString(), exception);
+        }
     }
 
     private @NotNull <T> T execute(final @NotNull String binary, final @NotNull String action, final @NotNull Type type, final @NotNull Project project) throws CommandFailedException {

--- a/src/main/java/de/php_perfect/intellij/ddev/errorReporting/SentryErrorReporter.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/errorReporting/SentryErrorReporter.java
@@ -17,6 +17,8 @@ import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.Consumer;
 import de.php_perfect.intellij.ddev.DdevIntegrationBundle;
+import de.php_perfect.intellij.ddev.cmd.CommandFailedException;
+import de.php_perfect.intellij.ddev.cmd.Ddev;
 import de.php_perfect.intellij.ddev.cmd.Versions;
 import de.php_perfect.intellij.ddev.notification.DdevNotifier;
 import de.php_perfect.intellij.ddev.state.DdevStateManager;
@@ -105,7 +107,17 @@ public class SentryErrorReporter extends ErrorReportSubmitter {
             return null;
         }
 
-        return DdevStateManager.getInstance(project).getState().getVersions();
+        final String binary = DdevStateManager.getInstance(project).getState().getDdevBinary();
+
+        if (binary == null) {
+            return null;
+        }
+
+        try {
+            return Ddev.getInstance().detailedVersions(binary, project);
+        } catch (CommandFailedException e) {
+            return null;
+        }
     }
 
     private @Nullable WSLDistribution getWslDistribution(@Nullable Project project) {

--- a/src/main/java/de/php_perfect/intellij/ddev/state/DdevStateManagerImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/state/DdevStateManagerImpl.java
@@ -114,7 +114,7 @@ public final class DdevStateManagerImpl implements DdevStateManager {
     private void checkIsInstalled(boolean autodetect) {
         DdevSettingsState configurable = DdevSettingsState.getInstance(this.project);
 
-        if (autodetect && configurable.ddevBinary.equals("")) {
+        if (autodetect && configurable.ddevBinary.isEmpty()) {
             String detectedDdevBinary = BinaryLocator.getInstance().findInPath(this.project);
 
             if (detectedDdevBinary != null) {
@@ -128,16 +128,16 @@ public final class DdevStateManagerImpl implements DdevStateManager {
 
     private void checkVersion() {
         if (!this.state.isBinaryConfigured()) {
-            this.state.setVersions(null);
+            this.state.setDdevVersion(null);
             this.state.setDescription(null);
             return;
         }
 
         try {
-            this.state.setVersions(Ddev.getInstance().version(Objects.requireNonNull(this.state.getDdevBinary()), this.project));
+            this.state.setDdevVersion(Ddev.getInstance().version(Objects.requireNonNull(this.state.getDdevBinary()), this.project));
         } catch (CommandFailedException exception) {
             LOG.error(exception);
-            this.state.setVersions(null);
+            this.state.setDdevVersion(null);
         }
     }
 

--- a/src/main/java/de/php_perfect/intellij/ddev/state/State.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/state/State.java
@@ -1,7 +1,7 @@
 package de.php_perfect.intellij.ddev.state;
 
 import de.php_perfect.intellij.ddev.cmd.Description;
-import de.php_perfect.intellij.ddev.cmd.Versions;
+import de.php_perfect.intellij.ddev.version.Version;
 import org.jetbrains.annotations.Nullable;
 
 public interface State {
@@ -11,7 +11,7 @@ public interface State {
 
     boolean isConfigured();
 
-    @Nullable Versions getVersions();
+    @Nullable Version getDdevVersion();
 
     @Nullable Description getDescription();
 

--- a/src/main/java/de/php_perfect/intellij/ddev/state/StateImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/state/StateImpl.java
@@ -1,7 +1,7 @@
 package de.php_perfect.intellij.ddev.state;
 
 import de.php_perfect.intellij.ddev.cmd.Description;
-import de.php_perfect.intellij.ddev.cmd.Versions;
+import de.php_perfect.intellij.ddev.version.Version;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
@@ -9,7 +9,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 final class StateImpl implements State {
-    private @Nullable Versions versions = null;
+    private @Nullable Version version = null;
 
     private @Nullable Description description = null;
 
@@ -21,12 +21,12 @@ final class StateImpl implements State {
 
     @Override
     public boolean isBinaryConfigured() {
-        return this.ddevBinary != null && !this.ddevBinary.equals("");
+        return this.ddevBinary != null && !this.ddevBinary.isEmpty();
     }
 
     @Override
     public boolean isAvailable() {
-        return this.versions != null;
+        return this.version != null;
     }
 
     @Override
@@ -47,22 +47,22 @@ final class StateImpl implements State {
         this.configured = configured;
     }
 
-    @Override
-    public @Nullable Versions getVersions() {
-        this.readWriteLock.readLock().lock();
+    public void setDdevVersion(@Nullable Version ddevVersion) {
+        this.readWriteLock.writeLock().lock();
         try {
-            return this.versions;
+            this.version = ddevVersion;
         } finally {
-            this.readWriteLock.readLock().unlock();
+            this.readWriteLock.writeLock().unlock();
         }
     }
 
-    public void setVersions(@Nullable Versions versions) {
-        this.readWriteLock.writeLock().lock();
+    @Override
+    public @Nullable Version getDdevVersion() {
+        this.readWriteLock.readLock().lock();
         try {
-            this.versions = versions;
+            return this.version;
         } finally {
-            this.readWriteLock.writeLock().unlock();
+            this.readWriteLock.readLock().unlock();
         }
     }
 
@@ -85,38 +85,38 @@ final class StateImpl implements State {
         }
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof StateImpl)) return false;
-        StateImpl state = (StateImpl) o;
-        return configured == state.configured && Objects.equals(versions, state.versions) && Objects.equals(description, state.description) && Objects.equals(ddevBinary, state.ddevBinary);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(versions, description, ddevBinary, configured);
-    }
-
-    @Override
-    public String toString() {
-        return "StateImpl{" +
-                "versions=" + versions +
-                ", description=" + description +
-                ", ddevBinary='" + ddevBinary + '\'' +
-                ", configured=" + configured +
-                '}';
-    }
-
     public void reset() {
         this.readWriteLock.writeLock().lock();
         try {
-            this.versions = null;
+            this.version = null;
             this.description = null;
             this.ddevBinary = null;
             this.configured = false;
         } finally {
             this.readWriteLock.writeLock().unlock();
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        StateImpl state = (StateImpl) o;
+        return isConfigured() == state.isConfigured() && Objects.equals(version, state.version) && Objects.equals(getDescription(), state.getDescription()) && Objects.equals(getDdevBinary(), state.getDdevBinary());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(version, getDescription(), getDdevBinary(), isConfigured());
+    }
+
+    @Override
+    public String toString() {
+        return "StateImpl{" +
+                "version=" + version +
+                ", description=" + description +
+                ", ddevBinary='" + ddevBinary + "'" +
+                ", configured=" + configured +
+                '}';
     }
 }

--- a/src/main/java/de/php_perfect/intellij/ddev/version/VersionCheckerImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/version/VersionCheckerImpl.java
@@ -4,7 +4,6 @@ import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
-import de.php_perfect.intellij.ddev.cmd.Versions;
 import de.php_perfect.intellij.ddev.notification.DdevNotifier;
 import de.php_perfect.intellij.ddev.settings.DdevSettingsState;
 import de.php_perfect.intellij.ddev.state.DdevStateManager;
@@ -27,16 +26,16 @@ public final class VersionCheckerImpl implements VersionChecker {
 
     @Override
     public void checkDdevVersion(boolean confirmNewestVersion) {
-        var settings = DdevSettingsState.getInstance(this.project);
+        final DdevSettingsState settings = DdevSettingsState.getInstance(this.project);
 
         if (!settings.checkForUpdates) {
             return;
         }
 
-        State state = DdevStateManager.getInstance(this.project).getState();
-        String currentVersion = this.getCurrentVersion(state);
+        final State state = DdevStateManager.getInstance(this.project).getState();
+        final Version currentVersion = this.getCurrentVersion(state);
 
-        if (currentVersion == null || currentVersion.equals("")) {
+        if (currentVersion == null) {
             if (state.isConfigured()) {
                 DdevNotifier.getInstance(project).notifyInstallDdev();
             }
@@ -53,10 +52,10 @@ public final class VersionCheckerImpl implements VersionChecker {
                     return;
                 }
 
-                final String latestVersion = latestRelease.getTagName();
+                final Version latestVersion = new Version(latestRelease.getTagName());
 
                 if (VersionCompare.needsUpdate(currentVersion, latestVersion)) {
-                    DdevNotifier.getInstance(project).notifyNewVersionAvailable(currentVersion, latestVersion);
+                    DdevNotifier.getInstance(project).notifyNewVersionAvailable(currentVersion.toString(), latestVersion.toString());
                 } else if (confirmNewestVersion) {
                     DdevNotifier.getInstance(project).notifyAlreadyLatestVersion();
                 }
@@ -64,17 +63,11 @@ public final class VersionCheckerImpl implements VersionChecker {
         });
     }
 
-    private @Nullable String getCurrentVersion(State state) {
+    private @Nullable Version getCurrentVersion(State state) {
         if (!state.isAvailable()) {
             return null;
         }
 
-        Versions versions = state.getVersions();
-
-        if (versions == null) {
-            return null;
-        }
-
-        return versions.getDdevVersion();
+        return state.getDdevVersion();
     }
 }

--- a/src/main/java/de/php_perfect/intellij/ddev/version/util/VersionCompare.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/version/util/VersionCompare.java
@@ -3,11 +3,8 @@ package de.php_perfect.intellij.ddev.version.util;
 import de.php_perfect.intellij.ddev.version.Version;
 
 public final class VersionCompare {
-    public static boolean needsUpdate(String currentVersion, String latestVersion) {
-        final Version current = new Version(currentVersion);
-        final Version latest = new Version(latestVersion);
-
-        return current.compareTo(latest) < 0;
+    public static boolean needsUpdate(Version currentVersion, Version latestVersion) {
+        return currentVersion.compareTo(latestVersion) < 0;
     }
 
     private VersionCompare() {

--- a/src/test/java/de/php_perfect/intellij/ddev/cmd/DdevImplTest.java
+++ b/src/test/java/de/php_perfect/intellij/ddev/cmd/DdevImplTest.java
@@ -3,6 +3,7 @@ package de.php_perfect.intellij.ddev.cmd;
 import com.intellij.execution.process.ProcessOutput;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import de.php_perfect.intellij.ddev.version.Version;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,7 +28,18 @@ final class DdevImplTest extends BasePlatformTestCase {
     }
 
     @Test
-    void version() throws CommandFailedException, IOException {
+    void version() throws CommandFailedException {
+        final Version expected = new Version("v1.22.0");
+        final ProcessOutput processOutput = new ProcessOutput("ddev version v1.22.0", "", 0, false, false);
+
+        final MockProcessExecutor mockProcessExecutor = (MockProcessExecutor) ApplicationManager.getApplication().getService(ProcessExecutor.class);
+        mockProcessExecutor.addProcessOutput("ddev --version --json-output", processOutput);
+
+        Assertions.assertEquals(expected, new DdevImpl().version("ddev", getProject()));
+    }
+
+    @Test
+    void detailedVersions() throws CommandFailedException, IOException {
         Versions expected = new Versions("v1.19.0", "20.10.12", "v2.2.2", "docker-desktop");
 
         ProcessOutput processOutput = new ProcessOutput(Files.readString(Path.of("src/test/resources/ddev_version.json")), "", 0, false, false);
@@ -35,7 +47,7 @@ final class DdevImplTest extends BasePlatformTestCase {
         MockProcessExecutor mockProcessExecutor = (MockProcessExecutor) ApplicationManager.getApplication().getService(ProcessExecutor.class);
         mockProcessExecutor.addProcessOutput("ddev version --json-output", processOutput);
 
-        Assertions.assertEquals(expected, new DdevImpl().version("ddev", getProject()));
+        Assertions.assertEquals(expected, new DdevImpl().detailedVersions("ddev", getProject()));
     }
 
     @Test

--- a/src/test/java/de/php_perfect/intellij/ddev/state/DdevStateManagerTest.java
+++ b/src/test/java/de/php_perfect/intellij/ddev/state/DdevStateManagerTest.java
@@ -8,7 +8,7 @@ import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import de.php_perfect.intellij.ddev.cmd.Description;
 import de.php_perfect.intellij.ddev.cmd.MockProcessExecutor;
 import de.php_perfect.intellij.ddev.cmd.ProcessExecutor;
-import de.php_perfect.intellij.ddev.cmd.Versions;
+import de.php_perfect.intellij.ddev.version.Version;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,8 +40,8 @@ final class DdevStateManagerTest extends BasePlatformTestCase {
         mockProcessExecutor.addProcessOutput(expectedWhich + " ddev", new ProcessOutput("/foo/bar/bin/ddev", "", 0, false, false));
 
         ddevConfigLoader.setExists(true);
-        this.prepareCommand("/foo/bar/bin/ddev version --json-output", "src/test/resources/ddev_version.json");
-        this.prepareCommand("/foo/bar/bin/ddev describe --json-output", "src/test/resources/ddev_describe.json");
+        this.prepareCommand("/foo/bar/bin/ddev --version --json-output", "ddev version v1.19.0");
+        this.prepareCommandWithOutputFromFile("/foo/bar/bin/ddev describe --json-output", "src/test/resources/ddev_describe.json");
 
         DdevStateManager ddevStateManager = DdevStateManager.getInstance(project);
         ddevStateManager.initialize();
@@ -49,7 +49,7 @@ final class DdevStateManagerTest extends BasePlatformTestCase {
         StateImpl expectedState = new StateImpl();
         expectedState.setDdevBinary("/foo/bar/bin/ddev");
         expectedState.setConfigured(true);
-        expectedState.setVersions(new Versions("v1.19.0", "20.10.12", "v2.2.2", "docker-desktop"));
+        expectedState.setDdevVersion(new Version("v1.19.0"));
         expectedState.setDescription(new Description("acol", "8.1", Description.Status.STOPPED, null, null, new HashMap<>(), null, "https://acol.ddev.site"));
 
         Assertions.assertEquals(expectedState, ddevStateManager.getState());
@@ -68,7 +68,7 @@ final class DdevStateManagerTest extends BasePlatformTestCase {
         StateImpl expectedState = new StateImpl();
         expectedState.setDdevBinary("");
         expectedState.setConfigured(true);
-        expectedState.setVersions(null);
+        expectedState.setDdevVersion(null);
         expectedState.setDescription(null);
 
         Assertions.assertEquals(expectedState, ddevStateManager.getState());
@@ -88,8 +88,8 @@ final class DdevStateManagerTest extends BasePlatformTestCase {
         mockProcessExecutor.addProcessOutput(expectedWhich + " ddev", new ProcessOutput("/foo/bar/bin/ddev", "", 0, false, false));
 
         ddevConfigLoader.setExists(true);
-        this.prepareCommand("/foo/bar/bin/ddev version --json-output", "src/test/resources/ddev_version.json");
-        this.prepareCommand("/foo/bar/bin/ddev describe --json-output", "src/test/resources/ddev_describe.json");
+        this.prepareCommand("/foo/bar/bin/ddev --version --json-output", "ddev version v1.19.0");
+        this.prepareCommandWithOutputFromFile("/foo/bar/bin/ddev describe --json-output", "src/test/resources/ddev_describe.json");
 
         DdevStateManager ddevStateManager = DdevStateManager.getInstance(this.getProject());
         ddevStateManager.initialize();
@@ -97,12 +97,12 @@ final class DdevStateManagerTest extends BasePlatformTestCase {
         StateImpl expectedState = new StateImpl();
         expectedState.setDdevBinary("/foo/bar/bin/ddev");
         expectedState.setConfigured(true);
-        expectedState.setVersions(new Versions("v1.19.0", "20.10.12", "v2.2.2", "docker-desktop"));
+        expectedState.setDdevVersion(new Version("v1.19.0"));
         expectedState.setDescription(new Description("acol", "8.1", Description.Status.STOPPED, null, null, new HashMap<>(), null, "https://acol.ddev.site"));
 
         Assertions.assertEquals(expectedState, ddevStateManager.getState());
 
-        this.prepareCommand("/foo/bar/bin/ddev describe --json-output", "src/test/resources/ddev_describe2.json");
+        this.prepareCommandWithOutputFromFile("/foo/bar/bin/ddev describe --json-output", "src/test/resources/ddev_describe2.json");
 
         ddevStateManager.updateDescription();
 
@@ -111,17 +111,19 @@ final class DdevStateManagerTest extends BasePlatformTestCase {
         Assertions.assertEquals(expectedState, ddevStateManager.getState());
     }
 
-    private void prepareCommand(String command, String file) {
-        MockProcessExecutor mockProcessExecutor = (MockProcessExecutor) ApplicationManager.getApplication().getService(ProcessExecutor.class);
+    private void prepareCommand(String command, String output) {
+        final MockProcessExecutor mockProcessExecutor = (MockProcessExecutor) ApplicationManager.getApplication().getService(ProcessExecutor.class);
 
-        ProcessOutput processOutput = null;
+        final ProcessOutput processOutput = new ProcessOutput(output, "", 0, false, false);
+        mockProcessExecutor.addProcessOutput(command, processOutput);
+    }
+
+    private void prepareCommandWithOutputFromFile(String command, String file) {
         try {
-            processOutput = new ProcessOutput(Files.readString(Path.of(file)), "", 0, false, false);
+            this.prepareCommand(command, Files.readString(Path.of(file)));
         } catch (IOException e) {
             Assertions.fail(e);
         }
-
-        mockProcessExecutor.addProcessOutput(command, processOutput);
     }
 
     @Override

--- a/src/test/java/de/php_perfect/intellij/ddev/version/util/VersionCompareTest.java
+++ b/src/test/java/de/php_perfect/intellij/ddev/version/util/VersionCompareTest.java
@@ -1,36 +1,37 @@
 package de.php_perfect.intellij.ddev.version.util;
 
+import de.php_perfect.intellij.ddev.version.Version;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 final class VersionCompareTest {
     @Test
     void needsUpdateMajor() {
-        Assertions.assertTrue(VersionCompare.needsUpdate("1.0.0", "2.0.0"));
+        Assertions.assertTrue(VersionCompare.needsUpdate(new Version("1.0.0"), new Version("2.0.0")));
     }
 
     @Test
     void needsUpdateMinor() {
-        Assertions.assertTrue(VersionCompare.needsUpdate("1.0.0", "1.1.0"));
+        Assertions.assertTrue(VersionCompare.needsUpdate(new Version("1.0.0"), new Version("1.1.0")));
     }
 
     @Test
     void needsUpdatePatch() {
-        Assertions.assertTrue(VersionCompare.needsUpdate("1.0.0", "1.0.1"));
+        Assertions.assertTrue(VersionCompare.needsUpdate(new Version("1.0.0"), new Version("1.0.1")));
     }
 
     @Test
     void needsNoUpdateSame() {
-        Assertions.assertFalse(VersionCompare.needsUpdate("1.0.0", "1.0.0"));
+        Assertions.assertFalse(VersionCompare.needsUpdate(new Version("1.0.0"), new Version("1.0.0")));
     }
 
     @Test
     void needsNoUpdateOnRc() {
-        Assertions.assertFalse(VersionCompare.needsUpdate("v1.19.0-rc1", "1.18.9"));
+        Assertions.assertFalse(VersionCompare.needsUpdate(new Version("v1.19.0-rc1"), new Version("1.18.9")));
     }
 
     @Test
     void needsNoUpdateLowerMinor() {
-        Assertions.assertFalse(VersionCompare.needsUpdate("1.0.0", "0.9.0"));
+        Assertions.assertFalse(VersionCompare.needsUpdate(new Version("1.0.0"), new Version("0.9.0")));
     }
 }


### PR DESCRIPTION
Use --version to retrieve the version of the ddev binary and collect debug data via version only on error reports.

## The Problem/Issue/Bug:

The plugin is using `ddev version` to collect information about the current binary of ddev as well as 3rd party binary versions to use them for debugging purposes in case of an error.
This command requires docker to run and is not very performant.

## How this PR Solves the Problem:

To boostrap the plugin, the presence of ddev is checked using `ddev --version` and in case of a error report the output of `ddev version` is parsed.
Thanks to @rfay for suggesting this change.

## Manual Testing Instructions:

## Related Issue Link(s):
