### PR TITLE
Fix Docker.exe not found error

### DIFF
--- a/src/main/java/de/php_perfect/intellij/ddev/dockerCompose/DockerComposeCredentialProviderImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/dockerCompose/DockerComposeCredentialProviderImpl.java
@@ -23,7 +23,7 @@ public final class DockerComposeCredentialProviderImpl implements DockerComposeC
         credentials.setComposeFilePaths(composeFilePaths);
         credentials.setComposeServiceName(SERVICE_NAME);
         credentials.setRemoteProjectPath(DockerCredentialsEditor.DEFAULT_DOCKER_PROJECT_PATH);
-        credentials.setEnvs(EnvironmentVariablesData.create(Map.of(COMPOSE_PROJECT_NAME_ENV, "ddev-" + projectName), false));
+        credentials.setEnvs(EnvironmentVariablesData.create(Map.of(COMPOSE_PROJECT_NAME_ENV, "ddev-" + projectName), true));
 
         return credentials;
     }


### PR DESCRIPTION
## The Problem/Issue/Bug:

The Docker credentials configuration created by this plugin did not include the environment variables of the parent process which could lead to a
""docker.exe": executable file not found in %PATH%" error.

## How this PR Solves the Problem:

Include parent process environment variables for the created docker credentials holder.

## Manual Testing Instructions:

## Related Issue Link(s):

* #187
