### PR TITLE
Add silverstripe, plural upload_dirs

### DIFF
--- a/src/main/resources/schema/ddev-config-1.22.schema.json
+++ b/src/main/resources/schema/ddev-config-1.22.schema.json
@@ -50,7 +50,8 @@
         "shopware6",
         "typo3",
         "wordpress",
-        "craftcms"
+        "craftcms",
+        "silverstripe"
       ]
     },
     "docroot": {
@@ -190,6 +191,13 @@
       "description": "Sets the project's upload directory, the destination directory of the import-files command",
       "example": "custom/upload/dir",
       "type": "string"
+    },
+    "upload_dirs": {
+      "description": "Sets multiple project upload directories, the first is taken as the destination directory of the import-files command",
+      "type": "array"
+      "items": {
+        "type": "string"
+      }
     },
     "working_dir": {
       "description": "Override default project working directories for db and web service",


### PR DESCRIPTION
## The Problem/Issue/Bug:

Plural for upload dirs and silverstripe as project type were not yet allowed in the schema.

## How this PR Solves the Problem:

Add these values to the schema

## Manual Testing Instructions:

Add a plural array of upload_dirs to the ddev project config, or create a silverstripe project type

