### PR TITLE
Fix display issue of the ddev version in the update notification

### DIFF
--- a/src/main/java/de/php_perfect/intellij/ddev/notification/DdevNotifierImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/notification/DdevNotifierImpl.java
@@ -29,7 +29,7 @@ public final class DdevNotifierImpl implements DdevNotifier {
                         NotificationType.INFORMATION
                 )
                 .addAction(new InstallationInstructionsAction())
-                .notify(this.project), ModalityState.NON_MODAL);
+                .notify(this.project), ModalityState.nonModal());
     }
 
     @Override
@@ -43,7 +43,7 @@ public final class DdevNotifierImpl implements DdevNotifier {
                 )
                 .addAction(new InstallationInstructionsAction())
                 .addAction(new DisableCheckForUpdatesAction())
-                .notify(this.project), ModalityState.NON_MODAL);
+                .notify(this.project), ModalityState.nonModal());
     }
 
     @Override
@@ -54,7 +54,7 @@ public final class DdevNotifierImpl implements DdevNotifier {
                         DdevIntegrationBundle.message("notification.AlreadyLatestVersion.text"),
                         NotificationType.INFORMATION
                 )
-                .notify(this.project), ModalityState.NON_MODAL);
+                .notify(this.project), ModalityState.nonModal());
     }
 
     @Override
@@ -67,7 +67,7 @@ public final class DdevNotifierImpl implements DdevNotifier {
                         NotificationType.WARNING
                 )
                 .addAction(new ManagePluginsAction())
-                .notify(this.project), ModalityState.NON_MODAL);
+                .notify(this.project), ModalityState.nonModal());
     }
 
     @Override
@@ -79,7 +79,7 @@ public final class DdevNotifierImpl implements DdevNotifier {
                         DdevIntegrationBundle.message("notification.InterpreterUpdated.text", phpVersion),
                         NotificationType.INFORMATION
                 )
-                .notify(this.project), ModalityState.NON_MODAL);
+                .notify(this.project), ModalityState.nonModal());
     }
 
     @Override
@@ -93,7 +93,7 @@ public final class DdevNotifierImpl implements DdevNotifier {
                 )
                 .addAction(ActionManager.getInstance().getAction("DdevIntegration.SyncState"))
                 .addAction(new ReportIssueAction())
-                .notify(this.project), ModalityState.NON_MODAL);
+                .notify(this.project), ModalityState.nonModal());
     }
 
     @Override
@@ -106,7 +106,7 @@ public final class DdevNotifierImpl implements DdevNotifier {
                         NotificationType.INFORMATION
                 )
                 .addAction(new ReportIssueAction())
-                .notify(this.project), ModalityState.NON_MODAL);
+                .notify(this.project), ModalityState.nonModal());
     }
 
     @Override
@@ -119,7 +119,7 @@ public final class DdevNotifierImpl implements DdevNotifier {
                         NotificationType.INFORMATION
                 )
                 .addAction(new ChangeSettingsAction())
-                .notify(this.project), ModalityState.NON_MODAL);
+                .notify(this.project), ModalityState.nonModal());
     }
 
     @Override
@@ -132,6 +132,6 @@ public final class DdevNotifierImpl implements DdevNotifier {
                         NotificationType.WARNING
                 )
                 .addAction(new ReloadPluginAction())
-                .notify(this.project), ModalityState.NON_MODAL);
+                .notify(this.project), ModalityState.nonModal());
     }
 }

--- a/src/main/java/de/php_perfect/intellij/ddev/version/Version.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/version/Version.java
@@ -1,14 +1,18 @@
 package de.php_perfect.intellij.ddev.version;
 
-import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 
 public final class Version implements Comparable<Version> {
-    @NonNull
-    public final int[] numbers;
 
-    public Version(@NonNull String version) {
+    public final int @NotNull [] numbers;
+
+
+    public final @NotNull String string;
+
+    public Version(@NotNull String version) {
+        this.string = version;
         final String[] split = version.replaceAll("^v", "").split("-")[0].split("\\.");
         numbers = new int[split.length];
         for (int i = 0; i < split.length; i++) {
@@ -17,7 +21,7 @@ public final class Version implements Comparable<Version> {
     }
 
     @Override
-    public int compareTo(@NonNull Version another) {
+    public int compareTo(@NotNull Version another) {
         final int maxLength = Math.max(numbers.length, another.numbers.length);
         for (int i = 0; i < maxLength; i++) {
             final int left = i < numbers.length ? numbers[i] : 0;
@@ -40,5 +44,10 @@ public final class Version implements Comparable<Version> {
     @Override
     public int hashCode() {
         return Arrays.hashCode(numbers);
+    }
+
+    @Override
+    public String toString() {
+        return this.string;
     }
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:

The versions listed in the update notifications are displayed as Java Objects instead of the version string.

## How this PR Solves the Problem:

Implement toString method for the version object.

## Manual Testing Instructions:

Use an old ddev version and check the update notification.

## Related Issue Link(s):
