### PR TITLE
Add highlighting for ddev commands that can be executed in ui

### DIFF
--- a/src/main/java/de/php_perfect/intellij/ddev/cmd/DdevShellCommandHandlerImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/cmd/DdevShellCommandHandlerImpl.java
@@ -1,0 +1,76 @@
+package de.php_perfect.intellij.ddev.cmd;
+
+import com.intellij.execution.Executor;
+import com.intellij.openapi.project.Project;
+import com.intellij.terminal.TerminalShellCommandHandler;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class DdevShellCommandHandlerImpl implements TerminalShellCommandHandler {
+    static final @NotNull String PREFIX = "ddev ";
+
+    enum Action {
+        START,
+        STOP,
+        RESTART,
+        POWER_OFF,
+        DELETE,
+        SHARE,
+        CONFIG,
+    }
+
+    @Override
+    public boolean execute(@NotNull Project project, @Nullable String workingDirectory, boolean localSession, @NotNull String command, @NotNull Executor executor) {
+        final Action action = parseAction(command);
+
+        if (action == null) {
+            return false;
+        }
+
+        this.executeAction(action, project);
+
+        return true;
+    }
+
+    @Override
+    public boolean matches(@NotNull Project project, @Nullable String workingDirectory, boolean localSession, @NotNull String command) {
+        return parseAction(command) != null;
+    }
+
+    private Action parseAction(@NotNull String command) {
+        if (!command.startsWith(PREFIX)) {
+            return null;
+        }
+
+        final String actionString = command.substring(PREFIX.length()).trim();
+
+        return this.matchAction(actionString);
+    }
+
+    private Action matchAction(@NotNull String action) {
+        return switch (action) {
+            case "start" -> Action.START;
+            case "stop" -> Action.STOP;
+            case "restart" -> Action.RESTART;
+            case "poweroff" -> Action.POWER_OFF;
+            case "delete" -> Action.DELETE;
+            case "share" -> Action.SHARE;
+            case "config" -> Action.CONFIG;
+            default -> null;
+        };
+    }
+
+    private void executeAction(@NotNull Action action, @NotNull Project project) {
+        final DdevRunner ddevRunner = DdevRunner.getInstance();
+
+        switch (action) {
+            case START -> ddevRunner.start(project);
+            case STOP -> ddevRunner.stop(project);
+            case RESTART -> ddevRunner.restart(project);
+            case POWER_OFF -> ddevRunner.powerOff(project);
+            case DELETE -> ddevRunner.delete(project);
+            case SHARE -> ddevRunner.share(project);
+            case CONFIG -> ddevRunner.config(project);
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -103,6 +103,8 @@
                                 id="de.php_perfect.ddev.statusBar"/>
 
         <statistics.gotItTooltipAllowlist prefix="ddev.features"/>
+
+        <terminal.shellCommandHandler implementation="de.php_perfect.intellij.ddev.cmd.DdevShellCommandHandlerImpl"/>
     </extensions>
 
     <extensions defaultExtensionNs="JavaScript.JsonSchema">

--- a/src/test/java/de/php_perfect/intellij/ddev/cmd/DdevShellCommandHandlerTest.java
+++ b/src/test/java/de/php_perfect/intellij/ddev/cmd/DdevShellCommandHandlerTest.java
@@ -1,0 +1,49 @@
+package de.php_perfect.intellij.ddev.cmd;
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public final class DdevShellCommandHandlerTest extends BasePlatformTestCase {
+    @Override
+    @BeforeEach
+    protected void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @Override
+    @AfterEach
+    protected void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    @Test
+    void nonDdevCommand() {
+        final DdevShellCommandHandlerImpl ddevShellCommandHandlerImpl = new DdevShellCommandHandlerImpl();
+
+        Assertions.assertFalse(ddevShellCommandHandlerImpl.matches(this.getProject(), null, true, "cat abc"));
+    }
+
+    @Test
+    void incompleteDdevCommand() {
+        final DdevShellCommandHandlerImpl ddevShellCommandHandlerImpl = new DdevShellCommandHandlerImpl();
+
+        Assertions.assertFalse(ddevShellCommandHandlerImpl.matches(this.getProject(), null, true, "ddev "));
+    }
+
+    @Test
+    void unkownDdevCommand() {
+        final DdevShellCommandHandlerImpl ddevShellCommandHandlerImpl = new DdevShellCommandHandlerImpl();
+
+        Assertions.assertFalse(ddevShellCommandHandlerImpl.matches(this.getProject(), null, true, "ddev foo"));
+    }
+
+    @Test
+    void ddevCommand() {
+        final DdevShellCommandHandlerImpl ddevShellCommandHandlerImpl = new DdevShellCommandHandlerImpl();
+
+        Assertions.assertTrue(ddevShellCommandHandlerImpl.matches(this.getProject(), null, true, "ddev start"));
+    }
+}


### PR DESCRIPTION
## The Problem/Issue/Bug:

Ddev commands executed in the terminal do not trigger an update of the ddev status in the plugin.
By highlighting ddev commands and suggesting executing them by the plugin people might use this way to get a better expereince.

## How this PR Solves the Problem:

Ddev commands typed in a terminal window get highlighted and can be executed by the Plugin pressing Ctrl + Enter.
