### PR TITLE
refactor(cmd): Call nonModal() instead of NON_MODAL constant

### DIFF
--- a/src/main/java/de/php_perfect/intellij/ddev/cmd/RunnerImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/cmd/RunnerImpl.java
@@ -45,7 +45,7 @@ public final class RunnerImpl implements Runner, Disposable {
             } catch (ExecutionException exception) {
                 LOG.warn("An error occurred running " + commandLine.getCommandLineString(), exception);
             }
-        }, ModalityState.NON_MODAL);
+        }, ModalityState.nonModal());
     }
 
     private @NotNull ProcessHandler createProcessHandler(GeneralCommandLine commandLine) throws ExecutionException {


### PR DESCRIPTION
## The Problem/Issue/Bug:

`NON_MODAL` has been deprecated: https://github.com/JetBrains/intellij-community/blob/0c1f99dc08e1542c4f0da0e2361ac0599849ffa7/platform/core-api/src/com/intellij/openapi/application/ModalityState.java#L40-L43

## How this PR Solves the Problem:

Migrated `NON_MODAL` to `nonModal()` according to the suggestion in `@deprecated`.

## Manual Testing Instructions:

None.

## Related Issue Link(s):

None.