### PR TITLE
refactor(icons): Use the ClassLoader overload of getIcon

### DIFF
--- a/src/main/java/de/php_perfect/intellij/ddev/icons/DdevIntegrationIcons.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/icons/DdevIntegrationIcons.java
@@ -6,8 +6,8 @@ import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
 
 public final class DdevIntegrationIcons {
-    public static final @NotNull Icon DdevLogoColor = IconManager.getInstance().getIcon("/icons/ddevLogoColor.svg", DdevIntegrationIcons.class);
-    public static final @NotNull Icon DdevLogoMono = IconManager.getInstance().getIcon("/icons/ddevLogoGrey.svg", DdevIntegrationIcons.class);
+    public static final @NotNull Icon DdevLogoColor = IconManager.getInstance().getIcon("/icons/ddevLogoColor.svg", DdevIntegrationIcons.class.getClassLoader());
+    public static final @NotNull Icon DdevLogoMono = IconManager.getInstance().getIcon("/icons/ddevLogoGrey.svg", DdevIntegrationIcons.class.getClassLoader());
 
     private DdevIntegrationIcons() {
     }


### PR DESCRIPTION
## The Problem/Issue/Bug:

According to <https://github.com/JetBrains/intellij-community/blob/0c1f99dc08e1542c4f0da0e2361ac0599849ffa7/platform/util/src/com/intellij/ui/IconManager.kt#L53-L54>,
the `fun getIcon(path: String, aClass: Class<*>): Icon` signature has been deprecated.

## How this PR Solves the Problem:

Migrate it to `fun getIcon(path: String, classLoader: ClassLoader): Icon`.

## Manual Testing Instructions:

Tested manually in #242:

![CleanShot 2023-10-05 at 14 56 12@2x](https://github.com/php-perfect/ddev-intellij-plugin/assets/28441561/08795e85-bd3d-40b1-bc04-82d511193817)


## Related Issue Link(s):

None.