### PR TITLE
Add support of EAP build (233.*)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ java {
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
     type.set("IU")
-    version.set("IU-232.8660.185") // https://www.jetbrains.com/de-de/idea/download/other.html
+    version.set("233.8264.8-EAP-SNAPSHOT") // https://www.jetbrains.com/de-de/idea/download/other.html
     plugins.add("com.intellij.database") // bundled
     plugins.add("org.jetbrains.plugins.terminal") // bundled
     plugins.add("com.jetbrains.plugins.webDeployment") // bundled
@@ -48,9 +48,9 @@ intellij {
     plugins.add("Docker") // bundled
     plugins.add("NodeJS") // bundled
     plugins.add("org.jetbrains.plugins.node-remote-interpreter") // bundled
-    plugins.add("com.jetbrains.php:232.8660.185") // https://plugins.jetbrains.com/plugin/6610-php/versions
-    plugins.add("org.jetbrains.plugins.phpstorm-remote-interpreter:232.8660.142") // https://plugins.jetbrains.com/plugin/7511-php-remote-interpreter/versions
-    plugins.add("org.jetbrains.plugins.phpstorm-docker:232.8660.142") // https://plugins.jetbrains.com/plugin/8595-php-docker/versions
+    plugins.add("com.jetbrains.php:233.8264.9") // https://plugins.jetbrains.com/plugin/6610-php/versions
+    plugins.add("org.jetbrains.plugins.phpstorm-remote-interpreter:233.8264.8") // https://plugins.jetbrains.com/plugin/7511-php-remote-interpreter/versions
+    plugins.add("org.jetbrains.plugins.phpstorm-docker:233.8264.8") // https://plugins.jetbrains.com/plugin/8595-php-docker/versions
 }
 
 tasks {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -21,7 +21,7 @@
     ]]></description>
     <change-notes/>
 
-    <idea-version since-build="232.8660.185" until-build="232.*"/>
+    <idea-version since-build="232.8660.185" until-build="233.*"/>
     <depends>com.intellij.modules.platform</depends>
     <depends config-file="DdevIntegration-withTerminal.xml" optional="true">org.jetbrains.plugins.terminal</depends>
     <depends config-file="DdevIntegration-withDatabase.xml" optional="true">com.intellij.database</depends>


### PR DESCRIPTION
## The Problem/Issue/Bug:

This plugin is incompatible with 2023.3 EAP.

## How this PR Solves the Problem:

Upgrade extension versions to EAP.

![CleanShot 2023-10-05 at 14 37 35@2x](https://github.com/php-perfect/ddev-intellij-plugin/assets/28441561/e3d7932b-47b0-4864-822f-117e05b05d82)

![CleanShot 2023-10-05 at 14 51 56@2x](https://github.com/php-perfect/ddev-intellij-plugin/assets/28441561/d8364645-a157-4743-addc-32c5d2312a9c)

![CleanShot 2023-10-05 at 14 52 24@2x](https://github.com/php-perfect/ddev-intellij-plugin/assets/28441561/5092086b-b9d8-4749-b8ff-e76680efc3c2)


## Manual Testing Instructions:

Build integrated with #238, #239, #240, #241: 
[ddev-intellij-plugin-1.1.2-EAP.2.zip](https://github.com/php-perfect/ddev-intellij-plugin/files/12813162/ddev-intellij-plugin-1.1.2-EAP.2.zip)

## Related Issue Link(s):
