### PR TITLE
Fix `upload_dirs` in JSON schema

### DIFF
--- a/src/main/resources/schema/ddev-config-1.22.schema.json
+++ b/src/main/resources/schema/ddev-config-1.22.schema.json
@@ -194,7 +194,7 @@
     },
     "upload_dirs": {
       "description": "Sets multiple project upload directories, the first is taken as the destination directory of the import-files command",
-      "type": "array"
+      "type": "array",
       "items": {
         "type": "string"
       }


### PR DESCRIPTION
## The Problem/Issue/Bug:

`upload_dirs` is not working in JSON schema because of a missing comma.

## How this PR Solves the Problem:

Adds a comma.

## Manual Testing Instructions:

## Related Issue Link(s):
