### PR TITLE
Add index for generated configurations

### DIFF
--- a/src/main/java/de/php_perfect/intellij/ddev/cmd/DatabaseInfo.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/cmd/DatabaseInfo.java
@@ -17,57 +17,6 @@ public record DatabaseInfo(
         @SerializedName("postgres") POSTGRESQL,
     }
 
-    public DatabaseInfo(@Nullable Type type, @Nullable String version, int port, @Nullable String name, @Nullable String host, @Nullable String username, @Nullable String password, int publishedPort) {
-        this.type = type;
-        this.version = version;
-        this.port = port;
-        this.name = name;
-        this.host = host;
-        this.username = username;
-        this.password = password;
-        this.publishedPort = publishedPort;
-    }
-
-    @Override
-    public @Nullable Type type() {
-        return this.type;
-    }
-
-    @Override
-    public @Nullable String version() {
-        return this.version;
-    }
-
-    @Override
-    public int port() {
-        return this.port;
-    }
-
-    @Override
-    public @Nullable String name() {
-        return this.name;
-    }
-
-    @Override
-    public @Nullable String host() {
-        return this.host;
-    }
-
-    @Override
-    public @Nullable String username() {
-        return this.username;
-    }
-
-    @Override
-    public @Nullable String password() {
-        return this.password;
-    }
-
-    @Override
-    public int publishedPort() {
-        return this.publishedPort;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/de/php_perfect/intellij/ddev/cmd/DatabaseInfo.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/cmd/DatabaseInfo.java
@@ -5,36 +5,17 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
-public class DatabaseInfo {
+public record DatabaseInfo(
+        @SerializedName("database_type") de.php_perfect.intellij.ddev.cmd.DatabaseInfo.@Nullable Type type,
+        @SerializedName("database_version") @Nullable String version, @SerializedName("dbPort") int port,
+        @SerializedName("dbname") @Nullable String name, @SerializedName("host") @Nullable String host,
+        @SerializedName("username") @Nullable String username, @SerializedName("password") @Nullable String password,
+        @SerializedName("published_port") int publishedPort) {
     public enum Type {
         @SerializedName("mysql") MYSQL,
         @SerializedName("mariadb") MARIADB,
         @SerializedName("postgres") POSTGRESQL,
     }
-
-    @SerializedName("database_type")
-    private final @Nullable Type type;
-
-    @SerializedName("database_version")
-    private final @Nullable String version;
-
-    @SerializedName("dbPort")
-    private final int port;
-
-    @SerializedName("dbname")
-    private final @Nullable String name;
-
-    @SerializedName("host")
-    private final @Nullable String host;
-
-    @SerializedName("username")
-    private final @Nullable String username;
-
-    @SerializedName("password")
-    private final @Nullable String password;
-
-    @SerializedName("published_port")
-    private final int publishedPort;
 
     public DatabaseInfo(@Nullable Type type, @Nullable String version, int port, @Nullable String name, @Nullable String host, @Nullable String username, @Nullable String password, int publishedPort) {
         this.type = type;
@@ -47,49 +28,51 @@ public class DatabaseInfo {
         this.publishedPort = publishedPort;
     }
 
-    public @Nullable Type getType() {
+    @Override
+    public @Nullable Type type() {
         return this.type;
     }
 
-    public @Nullable String getVersion() {
+    @Override
+    public @Nullable String version() {
         return this.version;
     }
 
-    public int getPort() {
+    @Override
+    public int port() {
         return this.port;
     }
 
-    public @Nullable String getName() {
+    @Override
+    public @Nullable String name() {
         return this.name;
     }
 
-    public @Nullable String getHost() {
+    @Override
+    public @Nullable String host() {
         return this.host;
     }
 
-    public @Nullable String getUsername() {
+    @Override
+    public @Nullable String username() {
         return this.username;
     }
 
-    public @Nullable String getPassword() {
+    @Override
+    public @Nullable String password() {
         return this.password;
     }
 
-    public int getPublishedPort() {
+    @Override
+    public int publishedPort() {
         return this.publishedPort;
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof DatabaseInfo)) return false;
-        DatabaseInfo that = (DatabaseInfo) o;
+        if (!(o instanceof DatabaseInfo that)) return false;
         return port == that.port && publishedPort == that.publishedPort && type == that.type && Objects.equals(version, that.version) && Objects.equals(name, that.name) && Objects.equals(host, that.host) && Objects.equals(username, that.username) && Objects.equals(password, that.password);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(type, version, port, name, host, username, password, publishedPort);
     }
 
     @Override

--- a/src/main/java/de/php_perfect/intellij/ddev/database/AutoConfigureDataSourceListener.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/database/AutoConfigureDataSourceListener.java
@@ -1,6 +1,5 @@
 package de.php_perfect.intellij.ddev.database;
 
-import com.intellij.database.dataSource.LocalDataSource;
 import com.intellij.openapi.project.Project;
 import de.php_perfect.intellij.ddev.DatabaseInfoChangedListener;
 import de.php_perfect.intellij.ddev.cmd.DatabaseInfo;
@@ -9,7 +8,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public final class AutoConfigureDataSourceListener implements DatabaseInfoChangedListener {
+    private static final @NotNull String HOST = "127.0.0.1";
     private final @NotNull Project project;
+
 
     public AutoConfigureDataSourceListener(@NotNull Project project) {
         this.project = project;
@@ -25,12 +26,16 @@ public final class AutoConfigureDataSourceListener implements DatabaseInfoChange
             return;
         }
 
-        LocalDataSource dataSource = DataSourceProvider.getInstance().buildDdevDataSource(databaseInfo);
-
-        if (dataSource == null) {
+        if (databaseInfo.type() == null || databaseInfo.version() == null || databaseInfo.name() == null || databaseInfo.username() == null || databaseInfo.password() == null) {
             return;
         }
 
-        DdevDataSourceManager.getInstance(this.project).updateDdevDataSource(dataSource);
+        final DataSourceConfig.Type type = switch (databaseInfo.type()) {
+            case MYSQL -> DataSourceConfig.Type.MYSQL;
+            case MARIADB -> DataSourceConfig.Type.MARIADB;
+            case POSTGRESQL -> DataSourceConfig.Type.POSTGRESQL;
+        };
+
+        DdevDataSourceManager.getInstance(this.project).updateDdevDataSource(new DataSourceConfig("DDEV", "DDEV generated data source", type, databaseInfo.version(), HOST, databaseInfo.publishedPort(), databaseInfo.name(), databaseInfo.username(), databaseInfo.password()));
     }
 }

--- a/src/main/java/de/php_perfect/intellij/ddev/database/DataSourceConfig.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/database/DataSourceConfig.java
@@ -1,0 +1,44 @@
+package de.php_perfect.intellij.ddev.database;
+
+import de.php_perfect.intellij.ddev.index.IndexableConfiguration;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public record DataSourceConfig(@NotNull String name, @NotNull String description, @NotNull Type type,
+                               @NotNull String version, @NotNull String host, int port, @NotNull String database,
+                               @NotNull String username, @NotNull String password) implements IndexableConfiguration {
+    public enum Type {
+        MYSQL,
+        MARIADB,
+        POSTGRESQL,
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DataSourceConfig that = (DataSourceConfig) o;
+        return port == that.port && Objects.equals(name, that.name) && Objects.equals(description, that.description) && type == that.type && Objects.equals(version, that.version) && Objects.equals(host, that.host) && Objects.equals(database, that.database) && Objects.equals(username, that.username) && Objects.equals(password, that.password);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, description, type, version, host, port, database, username, password);
+    }
+
+    @Override
+    public String toString() {
+        return "DataSourceConfig{" +
+                "name='" + name + '\'' +
+                ", description='" + description + '\'' +
+                ", type=" + type +
+                ", version='" + version + '\'' +
+                ", host='" + host + '\'' +
+                ", port=" + port +
+                ", database='" + database + '\'' +
+                ", username='" + username + '\'' +
+                ", password='" + password + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/de/php_perfect/intellij/ddev/database/DataSourceProvider.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/database/DataSourceProvider.java
@@ -2,12 +2,10 @@ package de.php_perfect.intellij.ddev.database;
 
 import com.intellij.database.dataSource.LocalDataSource;
 import com.intellij.openapi.application.ApplicationManager;
-import de.php_perfect.intellij.ddev.cmd.DatabaseInfo;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public interface DataSourceProvider {
-    @Nullable LocalDataSource buildDdevDataSource(@NotNull DatabaseInfo databaseInfo);
+    void updateDataSource(final @NotNull LocalDataSource dataSource, final @NotNull DataSourceConfig dataSourceConfig);
 
     static DataSourceProvider getInstance() {
         return ApplicationManager.getApplication().getService(DataSourceProvider.class);

--- a/src/main/java/de/php_perfect/intellij/ddev/database/DataSourceProviderImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/database/DataSourceProviderImpl.java
@@ -6,32 +6,27 @@ import com.intellij.database.dataSource.DatabaseDriverManager;
 import com.intellij.database.dataSource.LocalDataSource;
 import com.intellij.database.dataSource.SchemaControl;
 import com.intellij.database.introspection.DBIntrospectionOptions;
+import com.intellij.database.introspection.DBIntrospectorFeatures;
+import com.intellij.database.model.properties.Level;
 import com.intellij.database.util.TreePattern;
 import com.intellij.database.util.TreePatternUtils;
-import de.php_perfect.intellij.ddev.cmd.DatabaseInfo;
+import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import static com.intellij.database.introspection.DBIntrospectionConsts.ALL_NAMESPACES;
 
 public final class DataSourceProviderImpl implements DataSourceProvider {
+    public void updateDataSource(final @NotNull LocalDataSource dataSource, final @NotNull DataSourceConfig dataSourceConfig) {
+        final DatabaseDriver driver = this.getDriverByDatabaseType(dataSourceConfig.type(), dataSourceConfig.version());
+        final String dsn = getDsnByDatabaseType(dataSourceConfig);
 
-    public static final @NotNull String DSN_HOST = "127.0.0.1";
-
-    public @Nullable LocalDataSource buildDdevDataSource(@NotNull DatabaseInfo databaseInfo) {
-        final DatabaseInfo.Type databaseType = databaseInfo.getType();
-        if (databaseType == null) {
-            return null;
-        }
-
-        final DatabaseDriver driver = getDriverByDatabaseType(databaseType);
-        final String dsn = this.getDsnByDatabaseType(databaseInfo);
-
-        return buildDataSource(driver, dsn);
-    }
-
-    private @NotNull LocalDataSource buildDataSource(DatabaseDriver driver, String dsn) {
-        final LocalDataSource dataSource = buildDataSourceFromDriverAndUrl(driver, dsn);
+        dataSource.setUrlSmart(dsn);
+        dataSource.setDatabaseDriver(driver);
+        dataSource.setPasswordStorage(LocalDataSource.Storage.PERSIST);
+        dataSource.setName(dataSourceConfig.name());
+        dataSource.setComment(dataSourceConfig.description());
+        dataSource.setUsername(dataSourceConfig.username());
+        dataSource.setSchemaControl(SchemaControl.AUTOMATIC);
         dataSource.setAutoSynchronize(true);
         dataSource.setCheckOutdated(true);
         dataSource.setSourceLoading(DBIntrospectionOptions.SourceLoading.USER_AND_SYSTEM_SOURCES);
@@ -39,52 +34,37 @@ public final class DataSourceProviderImpl implements DataSourceProvider {
         final Dbms dbms = Dbms.forConnection(dataSource);
         final TreePattern treePattern = TreePatternUtils.importPattern(dbms, ALL_NAMESPACES);
         dataSource.setIntrospectionScope(treePattern);
-
-        return dataSource;
+        dataSource.setIntrospectionLevel(DBIntrospectorFeatures.supportsMultilevelIntrospection(dbms) ? Level.L3 : null);
     }
 
-    private @NotNull LocalDataSource buildDataSourceFromDriverAndUrl(DatabaseDriver driver, String connectionUrl) {
-        LocalDataSource dataSource = LocalDataSource.fromDriver(driver, connectionUrl, false);
-        dataSource.setName("DDEV");
-        dataSource.setComment("DDEV generated data source");
-        dataSource.setUsername("db");
-        dataSource.setConfiguredByUrl(true);
-        dataSource.setSchemaControl(SchemaControl.AUTOMATIC);
-
-        return dataSource;
+    private static @NotNull String getDsnByDatabaseType(final @NotNull DataSourceConfig databaseInfo) {
+        return String.format(
+                "jdbc:%s://%s:%d/%s?user=%s&password=%s",
+                getDsnType(databaseInfo.type()),
+                databaseInfo.host(),
+                databaseInfo.port(),
+                databaseInfo.database(),
+                databaseInfo.username(),
+                databaseInfo.password()
+        );
     }
 
-    private @NotNull DatabaseDriver getDriverByDatabaseType(@NotNull DatabaseInfo.Type databaseType) {
-        DatabaseDriverManager databaseDriverManager = DatabaseDriverManager.getInstance();
+    private @NotNull DatabaseDriver getDriverByDatabaseType(final @NotNull DataSourceConfig.Type databaseType, final @NotNull String version) {
+        final DatabaseDriverManager databaseDriverManager = DatabaseDriverManager.getInstance();
 
         return switch (databaseType) {
             case POSTGRESQL -> databaseDriverManager.getDriver("postgresql");
             case MARIADB -> databaseDriverManager.getDriver("mariadb");
-            default -> databaseDriverManager.getDriver("mysql.8");
+            case MYSQL ->
+                    new ComparableVersion(version).compareTo(new ComparableVersion("8.0")) < 0 ? databaseDriverManager.getDriver("mysql") : databaseDriverManager.getDriver("mysql.8");
         };
     }
 
-    private @NotNull String getDsnByDatabaseType(@NotNull DatabaseInfo databaseInfo) {
-        return String.format(
-                "jdbc:%s://%s:%d/%s?user=%s&password=%s",
-                getDsnType(databaseInfo.getType()),
-                DSN_HOST,
-                databaseInfo.getPublishedPort(),
-                databaseInfo.getName(),
-                databaseInfo.getUsername(),
-                databaseInfo.getPassword()
-        );
-    }
-
-    private static @NotNull String getDsnType(@Nullable DatabaseInfo.Type databaseType) {
-        if (databaseType == null) {
-            return "mysql";
-        }
-
+    private static @NotNull String getDsnType(final @NotNull DataSourceConfig.Type databaseType) {
         return switch (databaseType) {
             case POSTGRESQL -> "postgresql";
             case MARIADB -> "mariadb";
-            default -> "mysql";
+            case MYSQL -> "mysql";
         };
     }
 }

--- a/src/main/java/de/php_perfect/intellij/ddev/database/DdevDataSourceManager.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/database/DdevDataSourceManager.java
@@ -1,13 +1,12 @@
 package de.php_perfect.intellij.ddev.database;
 
-import com.intellij.database.dataSource.LocalDataSource;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 
 public interface DdevDataSourceManager {
-    void updateDdevDataSource(@NotNull LocalDataSource dataSource);
+    void updateDdevDataSource(final @NotNull DataSourceConfig dataSourceConfig);
 
-    static DdevDataSourceManager getInstance(@NotNull Project project) {
+    static DdevDataSourceManager getInstance(final @NotNull Project project) {
         return project.getService(DdevDataSourceManager.class);
     }
 }

--- a/src/main/java/de/php_perfect/intellij/ddev/database/DdevDataSourceManagerImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/database/DdevDataSourceManagerImpl.java
@@ -47,7 +47,7 @@ public final class DdevDataSourceManagerImpl implements DdevDataSourceManager {
         }
 
         if (localDataSource == null) {
-            localDataSource = new LocalDataSource();
+            localDataSource = localDataSourceManager.createEmpty();
             dataSources.add(localDataSource);
         }
 

--- a/src/main/java/de/php_perfect/intellij/ddev/database/DdevDataSourceManagerImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/database/DdevDataSourceManagerImpl.java
@@ -4,33 +4,61 @@ import com.intellij.database.dataSource.LocalDataSource;
 import com.intellij.database.dataSource.LocalDataSourceManager;
 import com.intellij.database.util.DataSourceUtil;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import de.php_perfect.intellij.ddev.index.IndexEntry;
+import de.php_perfect.intellij.ddev.index.ManagedConfigurationIndex;
 import org.jetbrains.annotations.NotNull;
 
 public final class DdevDataSourceManagerImpl implements DdevDataSourceManager {
+    private final static @NotNull String LEGACY_DATA_SOURCE_NAME = "DDEV";
+    private static final @NotNull Logger LOG = Logger.getInstance(DdevDataSourceManagerImpl.class);
     private final @NotNull Project project;
 
-    public DdevDataSourceManagerImpl(@NotNull Project project) {
+    public DdevDataSourceManagerImpl(final @NotNull Project project) {
         this.project = project;
     }
 
     @Override
-    public void updateDdevDataSource(@NotNull LocalDataSource dataSource) {
-        LocalDataSourceManager localDataSourceManager = LocalDataSourceManager.getInstance(this.project);
+    public void updateDdevDataSource(final @NotNull DataSourceConfig dataSourceConfig) {
+        final int hash = dataSourceConfig.hashCode();
+        final ManagedConfigurationIndex managedConfigurationIndex = ManagedConfigurationIndex.getInstance(this.project);
+        final IndexEntry indexEntry = managedConfigurationIndex.get(DataSourceConfig.class);
+
+        final LocalDataSourceManager localDataSourceManager = LocalDataSourceManager.getInstance(this.project);
+        final var dataSources = localDataSourceManager.getDataSources();
+
+        LocalDataSource localDataSource = null;
+        if (indexEntry != null && (localDataSource = dataSources.stream()
+                .filter(currentDataSource -> currentDataSource.getUniqueId().equals(indexEntry.id()))
+                .findFirst()
+                .orElse(null)) != null && indexEntry.hashEquals(hash)) {
+            LOG.debug(String.format("Data source configuration %s is up to date", dataSourceConfig.name()));
+            return;
+        }
+
+        LOG.debug(String.format("Updating data source configuration %s", dataSourceConfig.name()));
+
+        if (localDataSource == null) {
+            localDataSource = dataSources.stream()
+                    .filter(currentDataSource -> currentDataSource.getName().equals(LEGACY_DATA_SOURCE_NAME))
+                    .findFirst()
+                    .orElse(null);
+        }
+
+        if (localDataSource == null) {
+            localDataSource = new LocalDataSource();
+            dataSources.add(localDataSource);
+        }
+
+        final LocalDataSource dataSource = localDataSource;
+        DataSourceProvider.getInstance().updateDataSource(dataSource, dataSourceConfig);
 
         ApplicationManager.getApplication().invokeLater(() -> {
-            for (LocalDataSource currentLocalDataSource : localDataSourceManager.getDataSources()) {
-                if (currentLocalDataSource.getName().equals(dataSource.getName())) {
-                    if (currentLocalDataSource.equalConfiguration(dataSource)) {
-                        return;
-                    }
-
-                    localDataSourceManager.removeDataSource(currentLocalDataSource);
-                }
-            }
-
-            localDataSourceManager.addDataSource(dataSource);
+            localDataSourceManager.fireDataSourceUpdated(dataSource);
             DataSourceUtil.performAutoSyncTask(this.project, dataSource);
         });
+
+        managedConfigurationIndex.set(dataSource.getUniqueId(), DataSourceConfig.class, hash);
     }
 }

--- a/src/main/java/de/php_perfect/intellij/ddev/database/DdevDataSourceManagerImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/database/DdevDataSourceManagerImpl.java
@@ -11,7 +11,7 @@ import de.php_perfect.intellij.ddev.index.ManagedConfigurationIndex;
 import org.jetbrains.annotations.NotNull;
 
 public final class DdevDataSourceManagerImpl implements DdevDataSourceManager {
-    private final static @NotNull String LEGACY_DATA_SOURCE_NAME = "DDEV";
+    private static final @NotNull String LEGACY_DATA_SOURCE_NAME = "DDEV";
     private static final @NotNull Logger LOG = Logger.getInstance(DdevDataSourceManagerImpl.class);
     private final @NotNull Project project;
 

--- a/src/main/java/de/php_perfect/intellij/ddev/dockerCompose/DockerComposeConfig.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/dockerCompose/DockerComposeConfig.java
@@ -1,0 +1,31 @@
+package de.php_perfect.intellij.ddev.dockerCompose;
+
+import de.php_perfect.intellij.ddev.index.IndexableConfiguration;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Objects;
+
+public record DockerComposeConfig(@NotNull List<String> composeFilePaths,
+                                  @NotNull String projectName) implements IndexableConfiguration {
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DockerComposeConfig that = (DockerComposeConfig) o;
+        return Objects.equals(composeFilePaths, that.composeFilePaths) && Objects.equals(projectName, that.projectName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(composeFilePaths, projectName);
+    }
+
+    @Override
+    public String toString() {
+        return "DockerComposeConfig{" +
+                "composeFilePaths=" + composeFilePaths +
+                ", projectName='" + projectName + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/de/php_perfect/intellij/ddev/dockerCompose/DockerComposeCredentialProvider.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/dockerCompose/DockerComposeCredentialProvider.java
@@ -2,11 +2,10 @@ package de.php_perfect.intellij.ddev.dockerCompose;
 
 import com.intellij.docker.remote.DockerComposeCredentialsHolder;
 import com.intellij.openapi.application.ApplicationManager;
-
-import java.util.List;
+import org.jetbrains.annotations.NotNull;
 
 public interface DockerComposeCredentialProvider {
-    DockerComposeCredentialsHolder getDdevDockerComposeCredentials(List<String> composeFilePaths, String projectName);
+    DockerComposeCredentialsHolder getDdevDockerComposeCredentials(@NotNull DockerComposeConfig dockerComposeConfig);
 
     static DockerComposeCredentialProvider getInstance() {
         return ApplicationManager.getApplication().getService(DockerComposeCredentialProvider.class);

--- a/src/main/java/de/php_perfect/intellij/ddev/dockerCompose/DockerComposeCredentialProviderImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/dockerCompose/DockerComposeCredentialProviderImpl.java
@@ -5,25 +5,29 @@ import com.intellij.docker.remote.DockerComposeCredentialsHolder;
 import com.intellij.docker.remote.DockerComposeCredentialsType;
 import com.intellij.docker.remote.DockerCredentialsEditor;
 import com.intellij.execution.configuration.EnvironmentVariablesData;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.remoteServer.configuration.RemoteServersManager;
+import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
 import java.util.Map;
 
 public final class DockerComposeCredentialProviderImpl implements DockerComposeCredentialProvider {
     private static final String DOCKER_NAME = "Docker";
     private static final String SERVICE_NAME = "web";
     private static final String COMPOSE_PROJECT_NAME_ENV = "COMPOSE_PROJECT_NAME";
+    private static final @NotNull Logger LOG = Logger.getInstance(DockerComposeCredentialProviderImpl.class);
 
-    public DockerComposeCredentialsHolder getDdevDockerComposeCredentials(List<String> composeFilePaths, String projectName) {
+    public DockerComposeCredentialsHolder getDdevDockerComposeCredentials(@NotNull DockerComposeConfig dockerComposeConfig) {
         this.ensureDockerRemoteServer();
+
+        LOG.debug("Providing new docker credentials");
 
         final DockerComposeCredentialsHolder credentials = DockerComposeCredentialsType.getInstance().createCredentials();
         credentials.setAccountName(DOCKER_NAME);
-        credentials.setComposeFilePaths(composeFilePaths);
+        credentials.setComposeFilePaths(dockerComposeConfig.composeFilePaths());
         credentials.setComposeServiceName(SERVICE_NAME);
         credentials.setRemoteProjectPath(DockerCredentialsEditor.DEFAULT_DOCKER_PROJECT_PATH);
-        credentials.setEnvs(EnvironmentVariablesData.create(Map.of(COMPOSE_PROJECT_NAME_ENV, "ddev-" + projectName), true));
+        credentials.setEnvs(EnvironmentVariablesData.create(Map.of(COMPOSE_PROJECT_NAME_ENV, "ddev-" + dockerComposeConfig.projectName()), true));
 
         return credentials;
     }

--- a/src/main/java/de/php_perfect/intellij/ddev/index/IndexEntry.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/index/IndexEntry.java
@@ -1,0 +1,17 @@
+package de.php_perfect.intellij.ddev.index;
+
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+public record IndexEntry(@NonNls @NotNull String id, @NonNls @Nullable String hash) {
+    public boolean hashEquals(int hash) {
+        return this.hashEquals(Integer.toHexString(hash));
+    }
+
+    public boolean hashEquals(@Nullable String hash) {
+        return Objects.equals(hash(), hash);
+    }
+}

--- a/src/main/java/de/php_perfect/intellij/ddev/index/IndexableConfiguration.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/index/IndexableConfiguration.java
@@ -1,0 +1,5 @@
+package de.php_perfect.intellij.ddev.index;
+
+public interface IndexableConfiguration {
+    int hashCode();
+}

--- a/src/main/java/de/php_perfect/intellij/ddev/index/ManagedConfigurationIndex.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/index/ManagedConfigurationIndex.java
@@ -1,0 +1,19 @@
+package de.php_perfect.intellij.ddev.index;
+
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+
+public interface ManagedConfigurationIndex {
+    static ManagedConfigurationIndex getInstance(@NotNull Project project) {
+        return project.getService(ManagedConfigurationIndex.class);
+    }
+
+    void set(@NonNls @NotNull String id, @NotNull Class<?> type, int hash);
+
+    void remove(@NotNull Class<?> type);
+
+    boolean isManaged(@NonNls @NotNull String id, @NotNull Class<?> type);
+
+    boolean isUpToDate(@NotNull Class<?> type, int hash);
+}

--- a/src/main/java/de/php_perfect/intellij/ddev/index/ManagedConfigurationIndex.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/index/ManagedConfigurationIndex.java
@@ -3,17 +3,22 @@ package de.php_perfect.intellij.ddev.index;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public interface ManagedConfigurationIndex {
     static ManagedConfigurationIndex getInstance(@NotNull Project project) {
         return project.getService(ManagedConfigurationIndex.class);
     }
 
-    void set(@NonNls @NotNull String id, @NotNull Class<?> type, int hash);
+    void set(@NonNls @NotNull String id, @NotNull Class<? extends IndexableConfiguration> type, int hash);
 
-    void remove(@NotNull Class<?> type);
+    @Nullable IndexEntry get(@NotNull Class<? extends IndexableConfiguration> type);
 
-    boolean isManaged(@NonNls @NotNull String id, @NotNull Class<?> type);
+    void remove(@NotNull Class<? extends IndexableConfiguration> type);
 
-    boolean isUpToDate(@NotNull Class<?> type, int hash);
+    boolean isManaged(@NonNls @NotNull String id, @NotNull Class<? extends IndexableConfiguration> type);
+
+    boolean isUpToDate(@NotNull Class<? extends IndexableConfiguration> type, int hash);
+
+    void purge();
 }

--- a/src/main/java/de/php_perfect/intellij/ddev/index/ManagedConfigurationIndexImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/index/ManagedConfigurationIndexImpl.java
@@ -1,0 +1,83 @@
+package de.php_perfect.intellij.ddev.index;
+
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+
+public class ManagedConfigurationIndexImpl implements ManagedConfigurationIndex {
+    private static final @NotNull String NAMESPACE = "de.php_perfect.intellij.ddev.";
+    private static final @NotNull String HASH_SUFFIX = ".hash";
+    private final @NotNull Project project;
+
+    public ManagedConfigurationIndexImpl(@NotNull Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public void set(@NonNls @NotNull String id, @NotNull Class<?> type, int hash) {
+        this.setManagedConfiguration(id, type.getName(), Integer.toHexString(hash));
+    }
+
+    private void setManagedConfiguration(@NonNls @NotNull String id, @NonNls @NotNull String type, @NonNls @NotNull String hash) {
+        final String key = buildKey(type);
+        final PropertiesComponent propertiesComponent = PropertiesComponent.getInstance(this.project);
+
+        propertiesComponent.setValue(key, id);
+        propertiesComponent.setValue(buildHashKey(key), hash);
+    }
+
+    @Override
+    public boolean isManaged(@NonNls @NotNull String id, @NotNull Class<?> type) {
+        return this.isManagedConfiguration(id, type.getName());
+    }
+
+    private boolean isManagedConfiguration(@NonNls @NotNull String id, @NonNls @NotNull String type) {
+        final String key = buildKey(type);
+        final PropertiesComponent propertiesComponent = PropertiesComponent.getInstance(this.project);
+
+        if (!propertiesComponent.isValueSet(key)) {
+            return false;
+        }
+
+        return id.equals(propertiesComponent.getValue(key));
+    }
+
+    @Override
+    public boolean isUpToDate(@NotNull Class<?> type, int hash) {
+        return this.isUpToDate(type.getName(), Integer.toHexString(hash));
+    }
+
+    private boolean isUpToDate(@NonNls @NotNull String type, @NonNls @NotNull String hash) {
+        final String key = buildKey(type);
+        final String hashKey = buildHashKey(key);
+        final PropertiesComponent propertiesComponent = PropertiesComponent.getInstance(this.project);
+
+        return propertiesComponent.isValueSet(key) &&
+                propertiesComponent.isValueSet(hashKey) &&
+                propertiesComponent.getValue(hashKey, "").equals(hash);
+    }
+
+    @Override
+    public void remove(@NotNull Class<?> type) {
+        this.removeManagedConfiguration(type.getName());
+    }
+
+    private void removeManagedConfiguration(@NonNls @NotNull String type) {
+        final String key = buildKey(type);
+        final String hashKey = buildHashKey(key);
+
+        PropertiesComponent.getInstance(this.project).unsetValue(key);
+        PropertiesComponent.getInstance(this.project).unsetValue(hashKey);
+    }
+
+    @NotNull
+    private static String buildKey(@NonNls @NotNull String type) {
+        return NAMESPACE + type;
+    }
+
+    @NotNull
+    private static String buildHashKey(@NonNls @NotNull String key) {
+        return key + HASH_SUFFIX;
+    }
+}

--- a/src/main/java/de/php_perfect/intellij/ddev/index/ManagedConfigurationIndexImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/index/ManagedConfigurationIndexImpl.java
@@ -1,13 +1,21 @@
 package de.php_perfect.intellij.ddev.index;
 
 import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import org.apache.commons.lang3.ObjectUtils;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class ManagedConfigurationIndexImpl implements ManagedConfigurationIndex {
     private static final @NotNull String NAMESPACE = "de.php_perfect.intellij.ddev.";
+    private static final @NotNull String INDEX_KEY = NAMESPACE + "index";
     private static final @NotNull String HASH_SUFFIX = ".hash";
+    private static final @NotNull Logger LOG = Logger.getInstance(ManagedConfigurationIndexImpl.class);
     private final @NotNull Project project;
 
     public ManagedConfigurationIndexImpl(@NotNull Project project) {
@@ -15,7 +23,7 @@ public class ManagedConfigurationIndexImpl implements ManagedConfigurationIndex 
     }
 
     @Override
-    public void set(@NonNls @NotNull String id, @NotNull Class<?> type, int hash) {
+    public void set(@NonNls @NotNull String id, @NotNull Class<? extends IndexableConfiguration> type, int hash) {
         this.setManagedConfiguration(id, type.getName(), Integer.toHexString(hash));
     }
 
@@ -25,10 +33,37 @@ public class ManagedConfigurationIndexImpl implements ManagedConfigurationIndex 
 
         propertiesComponent.setValue(key, id);
         propertiesComponent.setValue(buildHashKey(key), hash);
+
+        final List<String> list = ObjectUtils.firstNonNull(propertiesComponent.getList(INDEX_KEY), List.of());
+        final ArrayList<String> mutableList = new ArrayList<>(list);
+        mutableList.add(key);
+        propertiesComponent.setList(INDEX_KEY, mutableList);
+
+        LOG.debug(String.format("Set managed configuration id '%s' for %s", id, type));
     }
 
     @Override
-    public boolean isManaged(@NonNls @NotNull String id, @NotNull Class<?> type) {
+    public @Nullable IndexEntry get(@NotNull Class<? extends IndexableConfiguration> type) {
+        return this.getManagedConfiguration(type.getName());
+    }
+
+    private @Nullable IndexEntry getManagedConfiguration(@NonNls @NotNull String type) {
+        final String key = buildKey(type);
+        final PropertiesComponent propertiesComponent = PropertiesComponent.getInstance(this.project);
+
+        final String id = propertiesComponent.getValue(key);
+
+        if(id == null){
+            return null;
+        }
+
+        final String hash = propertiesComponent.getValue(buildHashKey(key));
+
+        return new IndexEntry(id, hash);
+    }
+
+    @Override
+    public boolean isManaged(@NonNls @NotNull String id, @NotNull Class<? extends IndexableConfiguration> type) {
         return this.isManagedConfiguration(id, type.getName());
     }
 
@@ -44,7 +79,7 @@ public class ManagedConfigurationIndexImpl implements ManagedConfigurationIndex 
     }
 
     @Override
-    public boolean isUpToDate(@NotNull Class<?> type, int hash) {
+    public boolean isUpToDate(@NotNull Class<? extends IndexableConfiguration> type, int hash) {
         return this.isUpToDate(type.getName(), Integer.toHexString(hash));
     }
 
@@ -59,16 +94,40 @@ public class ManagedConfigurationIndexImpl implements ManagedConfigurationIndex 
     }
 
     @Override
-    public void remove(@NotNull Class<?> type) {
+    public void remove(@NotNull Class<? extends IndexableConfiguration> type) {
         this.removeManagedConfiguration(type.getName());
     }
 
     private void removeManagedConfiguration(@NonNls @NotNull String type) {
         final String key = buildKey(type);
         final String hashKey = buildHashKey(key);
+        final PropertiesComponent propertiesComponent = PropertiesComponent.getInstance(this.project);
 
-        PropertiesComponent.getInstance(this.project).unsetValue(key);
-        PropertiesComponent.getInstance(this.project).unsetValue(hashKey);
+        propertiesComponent.unsetValue(key);
+        propertiesComponent.unsetValue(hashKey);
+
+        final List<String> list = ObjectUtils.firstNonNull(propertiesComponent.getList(INDEX_KEY), List.of());
+        final ArrayList<String> mutableList = new ArrayList<>(list);
+        mutableList.remove(key);
+        propertiesComponent.setList(INDEX_KEY, mutableList);
+
+        LOG.debug(String.format("Removed managed configuration id for %s", type));
+    }
+
+    @Override
+    public void purge() {
+        final PropertiesComponent propertiesComponent = PropertiesComponent.getInstance(this.project);
+        final List<String> list = ObjectUtils.firstNonNull(propertiesComponent.getList(INDEX_KEY), List.of());
+
+        for (String key : list) {
+            final String hashKey = buildHashKey(key);
+            propertiesComponent.unsetValue(key);
+            propertiesComponent.unsetValue(hashKey);
+        }
+
+        propertiesComponent.setList(INDEX_KEY, List.of());
+
+        LOG.debug("Configuration index purged");
     }
 
     @NotNull

--- a/src/main/java/de/php_perfect/intellij/ddev/node/NodeInterpreterConfig.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/node/NodeInterpreterConfig.java
@@ -1,10 +1,12 @@
 package de.php_perfect.intellij.ddev.node;
 
+import de.php_perfect.intellij.ddev.index.IndexableConfiguration;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-public record NodeInterpreterConfig(@NotNull String name, @NotNull String composeFilePath, @NotNull String binaryPath) {
+public record NodeInterpreterConfig(@NotNull String name, @NotNull String composeFilePath,
+                                    @NotNull String binaryPath) implements IndexableConfiguration {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/de/php_perfect/intellij/ddev/node/NodeInterpreterProvider.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/node/NodeInterpreterProvider.java
@@ -4,9 +4,9 @@ import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 
 public interface NodeInterpreterProvider {
-    void configureNodeInterpreter(@NotNull NodeInterpreterConfig nodeInterpreterConfig);
+    void configureNodeInterpreter(final @NotNull NodeInterpreterConfig nodeInterpreterConfig);
 
-    static NodeInterpreterProvider getInstance(@NotNull Project project) {
+    static NodeInterpreterProvider getInstance(final @NotNull Project project) {
         return project.getService(NodeInterpreterProvider.class);
     }
 }

--- a/src/main/java/de/php_perfect/intellij/ddev/node/NodeInterpreterProviderImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/node/NodeInterpreterProviderImpl.java
@@ -5,11 +5,13 @@ import com.intellij.docker.remote.DockerComposeCredentialsType;
 import com.intellij.execution.ExecutionException;
 import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreterManager;
 import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreterRef;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.PathMappingSettings;
 import com.jetbrains.nodejs.remote.NodeJSRemoteInterpreterManager;
 import com.jetbrains.nodejs.remote.NodeJSRemoteSdkAdditionalData;
 import com.jetbrains.nodejs.remote.NodeRemoteInterpreters;
+import de.php_perfect.intellij.ddev.dockerCompose.DockerComposeConfig;
 import de.php_perfect.intellij.ddev.dockerCompose.DockerComposeCredentialProvider;
 import org.jetbrains.annotations.NotNull;
 
@@ -17,20 +19,23 @@ import java.util.List;
 
 public final class NodeInterpreterProviderImpl implements NodeInterpreterProvider {
     public static final @NotNull String NODEJS_HELPERS_PATH = ".webstorm_nodejs_helpers";
+    private static final @NotNull Logger LOG = Logger.getInstance(NodeInterpreterProviderImpl.class);
     private final @NotNull Project project;
 
-    public NodeInterpreterProviderImpl(@NotNull Project project) {
+    public NodeInterpreterProviderImpl(final @NotNull Project project) {
         this.project = project;
     }
 
-    public void configureNodeInterpreter(@NotNull NodeInterpreterConfig nodeInterpreterConfig) {
+    public void configureNodeInterpreter(final @NotNull NodeInterpreterConfig nodeInterpreterConfig) {
         final NodeRemoteInterpreters nodeRemoteInterpreters = NodeRemoteInterpreters.getInstance();
 
         if (!nodeRemoteInterpreters.getInterpreters().isEmpty()) {
             return;
         }
 
-        final DockerComposeCredentialsHolder credentials = DockerComposeCredentialProvider.getInstance().getDdevDockerComposeCredentials(List.of(nodeInterpreterConfig.composeFilePath()), nodeInterpreterConfig.name());
+        LOG.debug("Creating nodejs interpreter");
+
+        final DockerComposeCredentialsHolder credentials = DockerComposeCredentialProvider.getInstance().getDdevDockerComposeCredentials(new DockerComposeConfig(List.of(nodeInterpreterConfig.composeFilePath()), nodeInterpreterConfig.name()));
         final NodeJSRemoteSdkAdditionalData sdkData = this.buildNodeJSRemoteSdkAdditionalData(credentials, nodeInterpreterConfig.binaryPath());
         nodeRemoteInterpreters.add(sdkData);
 

--- a/src/main/java/de/php_perfect/intellij/ddev/php/DdevInterpreterConfig.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/php/DdevInterpreterConfig.java
@@ -1,10 +1,12 @@
 package de.php_perfect.intellij.ddev.php;
 
+import de.php_perfect.intellij.ddev.index.IndexableConfiguration;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-record DdevInterpreterConfig(@NotNull String name, @NotNull String phpVersion, @NotNull String composeFilePath) {
+public record DdevInterpreterConfig(@NotNull String name, @NotNull String phpVersion,
+                                    @NotNull String composeFilePath) implements IndexableConfiguration {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/de/php_perfect/intellij/ddev/php/PhpInterpreterProvider.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/php/PhpInterpreterProvider.java
@@ -4,9 +4,9 @@ import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 
 public interface PhpInterpreterProvider {
-    void registerInterpreter(@NotNull DdevInterpreterConfig interpreterConfig);
+    void registerInterpreter(final @NotNull DdevInterpreterConfig interpreterConfig);
 
-    static PhpInterpreterProvider getInstance(@NotNull Project project) {
+    static PhpInterpreterProvider getInstance(final @NotNull Project project) {
         return project.getService(PhpInterpreterProvider.class);
     }
 }

--- a/src/main/java/de/php_perfect/intellij/ddev/php/server/ServerConfig.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/php/server/ServerConfig.java
@@ -1,53 +1,31 @@
 package de.php_perfect.intellij.ddev.php.server;
 
+import de.php_perfect.intellij.ddev.index.IndexableConfiguration;
 import org.jetbrains.annotations.NotNull;
 
 import java.net.URI;
 import java.util.Objects;
 
-public final class ServerConfig {
-    private final @NotNull String localPath;
-
-    private final @NotNull String remotePath;
-
-    private final @NotNull URI url;
-
-    public ServerConfig(@NotNull String localPath, @NotNull String remotePathPath, @NotNull URI url) {
-        this.localPath = localPath;
-        this.remotePath = remotePathPath;
-        this.url = url;
-    }
-
-    public @NotNull String getLocalPath() {
-        return localPath;
-    }
-
-    public @NotNull String getRemotePath() {
-        return remotePath;
-    }
-
-    public @NotNull URI getUrl() {
-        return url;
-    }
-
+public record ServerConfig(@NotNull String localPath, @NotNull String remotePathPath,
+                           @NotNull URI url) implements IndexableConfiguration {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ServerConfig that = (ServerConfig) o;
-        return getLocalPath().equals(that.getLocalPath()) && getRemotePath().equals(that.getRemotePath()) && getUrl().equals(that.getUrl());
+        return Objects.equals(localPath, that.localPath) && Objects.equals(remotePathPath, that.remotePathPath) && Objects.equals(url, that.url);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getLocalPath(), getRemotePath(), getUrl());
+        return Objects.hash(localPath, remotePathPath, url);
     }
 
     @Override
     public String toString() {
         return "ServerConfig{" +
                 "localPath='" + localPath + '\'' +
-                ", remotePath='" + remotePath + '\'' +
+                ", remotePathPath='" + remotePathPath + '\'' +
                 ", url=" + url +
                 '}';
     }

--- a/src/main/java/de/php_perfect/intellij/ddev/php/server/ServerConfigManagerImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/php/server/ServerConfigManagerImpl.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Objects;
 
 public final class ServerConfigManagerImpl implements ServerConfigManager {
-    private final static @NotNull String LEGACY_SERVER_NAME = "DDEV";
+    private static final @NotNull String LEGACY_SERVER_NAME = "DDEV";
     private static final @NotNull Logger LOG = Logger.getInstance(ServerConfigManagerImpl.class);
 
     private final @NotNull Project project;

--- a/src/main/java/de/php_perfect/intellij/ddev/php/server/ServerConfigManagerImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/php/server/ServerConfigManagerImpl.java
@@ -5,12 +5,15 @@ import com.intellij.openapi.project.Project;
 import com.intellij.util.PathMappingSettings;
 import com.jetbrains.php.config.servers.PhpServer;
 import com.jetbrains.php.config.servers.PhpServersWorkspaceStateComponent;
+import de.php_perfect.intellij.ddev.index.IndexEntry;
 import de.php_perfect.intellij.ddev.index.ManagedConfigurationIndex;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.Objects;
 
 public final class ServerConfigManagerImpl implements ServerConfigManager {
+    private final static @NotNull String LEGACY_SERVER_NAME = "DDEV";
     private static final @NotNull Logger LOG = Logger.getInstance(ServerConfigManagerImpl.class);
 
     private final @NotNull Project project;
@@ -21,22 +24,28 @@ public final class ServerConfigManagerImpl implements ServerConfigManager {
 
     public void configure(final @NotNull ServerConfig serverConfig) {
         final int hash = serverConfig.hashCode();
-        final String fqdn = serverConfig.getUrl().getHost();
+        final String fqdn = serverConfig.url().getHost();
         final ManagedConfigurationIndex managedConfigurationIndex = ManagedConfigurationIndex.getInstance(this.project);
+        final IndexEntry indexEntry = managedConfigurationIndex.get(ServerConfig.class);
+        final List<PhpServer> servers = PhpServersWorkspaceStateComponent.getInstance(project).getServers();
+        PhpServer phpServer = null;
 
-        if (managedConfigurationIndex.isUpToDate(PhpServer.class, hash)) {
+        if (indexEntry != null && (phpServer = servers.stream()
+                .filter(currentPhpServer -> currentPhpServer.getId().equals(indexEntry.id()))
+                .findFirst()
+                .orElse(null)) != null && indexEntry.hashEquals(hash)) {
             LOG.debug(String.format("server configuration %s is up to date", fqdn));
             return;
         }
 
         LOG.debug(String.format("Updating server configuration %s", fqdn));
 
-        final List<PhpServer> servers = PhpServersWorkspaceStateComponent.getInstance(project).getServers();
-
-        PhpServer phpServer = servers.stream()
-                .filter(currentPhpServer -> managedConfigurationIndex.isManaged(currentPhpServer.getId(), PhpServer.class))
-                .findFirst()
-                .orElse(null);
+        if (phpServer == null) {
+            phpServer = servers.stream()
+                    .filter(currentPhpServer -> Objects.equals(currentPhpServer.getName(), LEGACY_SERVER_NAME))
+                    .findFirst()
+                    .orElse(null);
+        }
 
         if (phpServer == null) {
             phpServer = new PhpServer();
@@ -49,10 +58,10 @@ public final class ServerConfigManagerImpl implements ServerConfigManager {
         phpServer.setUsePathMappings(true);
 
         final List<PathMappingSettings.PathMapping> mappings = phpServer.getMappings();
-        final PathMappingSettings.PathMapping mapping = new PathMappingSettings.PathMapping(serverConfig.getLocalPath(), serverConfig.getRemotePath());
+        final PathMappingSettings.PathMapping mapping = new PathMappingSettings.PathMapping(serverConfig.localPath(), serverConfig.remotePathPath());
         mappings.clear();
         mappings.add(mapping);
 
-        managedConfigurationIndex.set(phpServer.getId(), PhpServer.class, hash);
+        managedConfigurationIndex.set(phpServer.getId(), ServerConfig.class, hash);
     }
 }

--- a/src/main/java/de/php_perfect/intellij/ddev/php/server/ServerConfigManagerImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/php/server/ServerConfigManagerImpl.java
@@ -2,18 +2,16 @@ package de.php_perfect.intellij.ddev.php.server;
 
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.PathMappingSettings;
 import com.jetbrains.php.config.servers.PhpServer;
 import com.jetbrains.php.config.servers.PhpServersWorkspaceStateComponent;
+import de.php_perfect.intellij.ddev.index.ManagedConfigurationIndex;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
 public final class ServerConfigManagerImpl implements ServerConfigManager {
     private static final @NotNull Logger LOG = Logger.getInstance(ServerConfigManagerImpl.class);
-
-    private static final @NotNull String SERVER_NAME = "DDEV";
 
     private final @NotNull Project project;
 
@@ -22,25 +20,39 @@ public final class ServerConfigManagerImpl implements ServerConfigManager {
     }
 
     public void configure(final @NotNull ServerConfig serverConfig) {
-        LOG.debug(String.format("Updating server configuration %s", SERVER_NAME));
-        this.addOrReplaceServer(
-                PhpServersWorkspaceStateComponent.getInstance(project).getServers(),
-                createServerConfiguration(serverConfig)
-        );
-    }
+        final int hash = serverConfig.hashCode();
+        final String fqdn = serverConfig.getUrl().getHost();
+        final ManagedConfigurationIndex managedConfigurationIndex = ManagedConfigurationIndex.getInstance(this.project);
 
-    private @NotNull PhpServer createServerConfiguration(final @NotNull ServerConfig serverConfig) {
-        final PhpServer phpServer = new PhpServer();
-        phpServer.setName(SERVER_NAME);
-        phpServer.setHost(serverConfig.getUrl().getHost());
+        if (managedConfigurationIndex.isUpToDate(PhpServer.class, hash)) {
+            LOG.debug(String.format("server configuration %s is up to date", fqdn));
+            return;
+        }
+
+        LOG.debug(String.format("Updating server configuration %s", fqdn));
+
+        final List<PhpServer> servers = PhpServersWorkspaceStateComponent.getInstance(project).getServers();
+
+        PhpServer phpServer = servers.stream()
+                .filter(currentPhpServer -> managedConfigurationIndex.isManaged(currentPhpServer.getId(), PhpServer.class))
+                .findFirst()
+                .orElse(null);
+
+        if (phpServer == null) {
+            phpServer = new PhpServer();
+            servers.add(phpServer);
+        }
+
+        phpServer.setName(fqdn);
+        phpServer.setHost(fqdn);
+        phpServer.setPort(80);
         phpServer.setUsePathMappings(true);
-        phpServer.getMappings().add(new PathMappingSettings.PathMapping(serverConfig.getLocalPath(), serverConfig.getRemotePath()));
 
-        return phpServer;
-    }
+        final List<PathMappingSettings.PathMapping> mappings = phpServer.getMappings();
+        final PathMappingSettings.PathMapping mapping = new PathMappingSettings.PathMapping(serverConfig.getLocalPath(), serverConfig.getRemotePath());
+        mappings.clear();
+        mappings.add(mapping);
 
-    private void addOrReplaceServer(final @NotNull List<PhpServer> servers, final @NotNull PhpServer server) {
-        servers.removeIf(phpServer -> StringUtil.equals(phpServer.getName(), server.getName()));
-        servers.add(server);
+        managedConfigurationIndex.set(phpServer.getId(), PhpServer.class, hash);
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -76,6 +76,8 @@
         <applicationService serviceImplementation="de.php_perfect.intellij.ddev.cmd.DockerImpl"
                             serviceInterface="de.php_perfect.intellij.ddev.cmd.Docker"/>
 
+        <projectService serviceImplementation="de.php_perfect.intellij.ddev.index.ManagedConfigurationIndexImpl"
+                        serviceInterface="de.php_perfect.intellij.ddev.index.ManagedConfigurationIndex"/>
         <projectService serviceImplementation="de.php_perfect.intellij.ddev.notification.DdevNotifierImpl"
                         serviceInterface="de.php_perfect.intellij.ddev.notification.DdevNotifier"/>
         <projectService serviceImplementation="de.php_perfect.intellij.ddev.state.DdevConfigLoaderImpl"

--- a/src/test/java/de/php_perfect/intellij/ddev/database/DataSourceProviderTest.java
+++ b/src/test/java/de/php_perfect/intellij/ddev/database/DataSourceProviderTest.java
@@ -2,7 +2,6 @@ package de.php_perfect.intellij.ddev.database;
 
 import com.intellij.database.dataSource.LocalDataSource;
 import com.intellij.testFramework.fixtures.BasePlatformTestCase;
-import de.php_perfect.intellij.ddev.cmd.DatabaseInfo;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,37 +22,53 @@ final class DataSourceProviderTest extends BasePlatformTestCase {
 
     @Test
     void mySql() {
-        DatabaseInfo databaseInfo = new DatabaseInfo(DatabaseInfo.Type.MYSQL, "8.0", 533, "", "some-internal-host", "some-user", "some-password", 12345);
+        final DataSourceConfig dataSourceConfig = new DataSourceConfig("DDEV", "Some Description", DataSourceConfig.Type.MYSQL, "8.0", "127.0.0.1", 12345, "db", "some-user", "some-password");
 
-        DataSourceProviderImpl dataSourceProvider = new DataSourceProviderImpl();
+        final LocalDataSource dataSource = new LocalDataSource();
+        new DataSourceProviderImpl().updateDataSource(dataSource, dataSourceConfig);
 
-        LocalDataSource dataSource = dataSourceProvider.buildDdevDataSource(databaseInfo);
         Assertions.assertInstanceOf(LocalDataSource.class, dataSource);
         Assertions.assertNotNull(dataSource);
-        Assertions.assertEquals("jdbc:mysql://127.0.0.1:12345/?user=some-user&password=some-password", dataSource.getUrl());
+        Assertions.assertNotNull(dataSource.getDatabaseDriver());
+        Assertions.assertEquals("mysql.8", dataSource.getDatabaseDriver().getId());
+        Assertions.assertEquals("jdbc:mysql://127.0.0.1:12345/db?user=some-user&password=some-password", dataSource.getUrl());
+    }
+
+    @Test
+    void mySql56() {
+        final DataSourceConfig dataSourceConfig = new DataSourceConfig("DDEV", "Some Description", DataSourceConfig.Type.MYSQL, "5.6", "127.0.0.1", 12345, "db", "some-user", "some-password");
+
+        final LocalDataSource dataSource = new LocalDataSource();
+        new DataSourceProviderImpl().updateDataSource(dataSource, dataSourceConfig);
+
+        Assertions.assertInstanceOf(LocalDataSource.class, dataSource);
+        Assertions.assertNotNull(dataSource);
+        Assertions.assertNotNull(dataSource.getDatabaseDriver());
+        Assertions.assertEquals("mysql", dataSource.getDatabaseDriver().getId());
+        Assertions.assertEquals("jdbc:mysql://127.0.0.1:12345/db?user=some-user&password=some-password", dataSource.getUrl());
     }
 
     @Test
     void mariaDb() {
-        DatabaseInfo databaseInfo = new DatabaseInfo(DatabaseInfo.Type.MARIADB, "10.4", 533, "", "some-internal-host", "some-user", "some-password", 12345);
+        final DataSourceConfig dataSourceConfig = new DataSourceConfig("DDEV", "Some Description", DataSourceConfig.Type.MARIADB, "10.4", "127.0.0.1", 12345, "db", "some-user", "some-password");
 
-        DataSourceProviderImpl dataSourceProvider = new DataSourceProviderImpl();
+        final LocalDataSource dataSource = new LocalDataSource();
+        new DataSourceProviderImpl().updateDataSource(dataSource, dataSourceConfig);
 
-        LocalDataSource dataSource = dataSourceProvider.buildDdevDataSource(databaseInfo);
         Assertions.assertInstanceOf(LocalDataSource.class, dataSource);
         Assertions.assertNotNull(dataSource);
-        Assertions.assertEquals("jdbc:mariadb://127.0.0.1:12345/?user=some-user&password=some-password", dataSource.getUrl());
+        Assertions.assertEquals("jdbc:mariadb://127.0.0.1:12345/db?user=some-user&password=some-password", dataSource.getUrl());
     }
 
     @Test
     void postgreSql() {
-        DatabaseInfo databaseInfo = new DatabaseInfo(DatabaseInfo.Type.POSTGRESQL, "8.0", 533, "", "some-internal-host", "some-user", "some-password", 12345);
+        final DataSourceConfig dataSourceConfig = new DataSourceConfig("DDEV", "Some Description", DataSourceConfig.Type.POSTGRESQL, "15.5", "127.0.0.1", 12345, "db", "some-user", "some-password");
 
-        DataSourceProviderImpl dataSourceProvider = new DataSourceProviderImpl();
+        final LocalDataSource dataSource = new LocalDataSource();
+        new DataSourceProviderImpl().updateDataSource(dataSource, dataSourceConfig);
 
-        LocalDataSource dataSource = dataSourceProvider.buildDdevDataSource(databaseInfo);
         Assertions.assertInstanceOf(LocalDataSource.class, dataSource);
         Assertions.assertNotNull(dataSource);
-        Assertions.assertEquals("jdbc:postgresql://127.0.0.1:12345/?user=some-user&password=some-password", dataSource.getUrl());
+        Assertions.assertEquals("jdbc:postgresql://127.0.0.1:12345/db?user=some-user&password=some-password", dataSource.getUrl());
     }
 }

--- a/src/test/java/de/php_perfect/intellij/ddev/index/ManagedConfigurationIndexTest.java
+++ b/src/test/java/de/php_perfect/intellij/ddev/index/ManagedConfigurationIndexTest.java
@@ -1,0 +1,78 @@
+package de.php_perfect.intellij.ddev.index;
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ManagedConfigurationIndexTest extends BasePlatformTestCase {
+    private static class SomeConfiguration {
+    }
+
+    private static class SomeOtherConfiguration {
+    }
+
+    @Override
+    @BeforeEach
+    protected void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @Test
+    void addToIndexCheckId() {
+        final ManagedConfigurationIndex managedConfigurationIndex = ManagedConfigurationIndex.getInstance(this.getProject());
+        managedConfigurationIndex.set("as73asvb324", SomeConfiguration.class, 123);
+
+        assertTrue(managedConfigurationIndex.isManaged("as73asvb324", SomeConfiguration.class));
+        assertFalse(managedConfigurationIndex.isManaged("fooBar", SomeConfiguration.class));
+    }
+
+    @Test
+    void addToIndexCheckType() {
+        final String key = "as73asvb324";
+        final ManagedConfigurationIndex managedConfigurationIndex = ManagedConfigurationIndex.getInstance(this.getProject());
+        managedConfigurationIndex.set(key, SomeConfiguration.class, 123);
+
+        assertTrue(managedConfigurationIndex.isManaged(key, SomeConfiguration.class));
+        assertFalse(managedConfigurationIndex.isManaged(key, SomeOtherConfiguration.class));
+    }
+
+    @Test
+    void removeIndex() {
+        final String key = "as73asvb324";
+        final ManagedConfigurationIndex managedConfigurationIndex = ManagedConfigurationIndex.getInstance(this.getProject());
+
+        managedConfigurationIndex.set(key, SomeConfiguration.class, 123);
+        assertTrue(managedConfigurationIndex.isManaged(key, SomeConfiguration.class));
+
+        managedConfigurationIndex.remove(SomeConfiguration.class);
+        assertFalse(managedConfigurationIndex.isManaged(key, SomeConfiguration.class));
+    }
+
+    @Test
+    void isUpToDate() {
+        final String key = "as73asvb324";
+        final ManagedConfigurationIndex managedConfigurationIndex = ManagedConfigurationIndex.getInstance(this.getProject());
+
+        managedConfigurationIndex.set(key, SomeConfiguration.class, 123);
+        assertTrue(managedConfigurationIndex.isUpToDate(SomeConfiguration.class, 123));
+        assertFalse(managedConfigurationIndex.isUpToDate(SomeConfiguration.class, 321));
+    }
+
+    @Test
+    void isUpToDateNonExistent() {
+        final ManagedConfigurationIndex managedConfigurationIndex = ManagedConfigurationIndex.getInstance(this.getProject());
+
+        assertFalse(managedConfigurationIndex.isUpToDate(SomeConfiguration.class, 123));
+    }
+
+    @Override
+    @AfterEach
+    protected void tearDown() throws Exception {
+        final ManagedConfigurationIndex managedConfigurationIndex = ManagedConfigurationIndex.getInstance(this.getProject());
+        managedConfigurationIndex.remove(SomeConfiguration.class);
+        managedConfigurationIndex.remove(SomeOtherConfiguration.class);
+
+        super.tearDown();
+    }
+}

--- a/src/test/java/de/php_perfect/intellij/ddev/index/ManagedConfigurationIndexTest.java
+++ b/src/test/java/de/php_perfect/intellij/ddev/index/ManagedConfigurationIndexTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ManagedConfigurationIndexTest extends BasePlatformTestCase {
+class ManagedConfigurationIndexTest extends BasePlatformTestCase {
     private static class SomeConfiguration implements IndexableConfiguration {
         @Override
         public int hashCode() {

--- a/src/test/java/de/php_perfect/intellij/ddev/php/server/ServerConfigManagerImplTest.java
+++ b/src/test/java/de/php_perfect/intellij/ddev/php/server/ServerConfigManagerImplTest.java
@@ -58,7 +58,7 @@ final class ServerConfigManagerImplTest extends BasePlatformTestCase {
 
         var mapping = mappings.get(0);
 
-        Assert.assertEquals(serverConfig.getLocalPath(), mapping.getLocalRoot());
-        Assert.assertEquals(serverConfig.getRemotePath(), mapping.getRemoteRoot());
+        Assert.assertEquals(serverConfig.localPath(), mapping.getLocalRoot());
+        Assert.assertEquals(serverConfig.remotePathPath(), mapping.getRemoteRoot());
     }
 }

--- a/src/test/java/de/php_perfect/intellij/ddev/php/server/ServerConfigManagerImplTest.java
+++ b/src/test/java/de/php_perfect/intellij/ddev/php/server/ServerConfigManagerImplTest.java
@@ -29,19 +29,18 @@ final class ServerConfigManagerImplTest extends BasePlatformTestCase {
 
     @Test
     void configure() throws URISyntaxException {
-        final ServerConfigManager serverConfigManager = ServerConfigManager.getInstance(this.getProject());
-
         final ServerConfig serverConfig = new ServerConfig(
                 Objects.requireNonNull(this.getProject().getBasePath()),
                 "/var/www/html",
                 new URI("https://test.ddev.site")
         );
 
+        final ServerConfigManager serverConfigManager = ServerConfigManager.getInstance(this.getProject());
         serverConfigManager.configure(serverConfig);
         // Check server gets replaced
         serverConfigManager.configure(serverConfig);
 
-        assertServerConfigMatches(serverConfig);
+        this.assertServerConfigMatches(serverConfig);
     }
 
     private void assertServerConfigMatches(ServerConfig serverConfig) {
@@ -50,7 +49,7 @@ final class ServerConfigManagerImplTest extends BasePlatformTestCase {
         Assert.assertEquals(1, servers.size());
 
         final PhpServer server = servers.get(0);
-        Assert.assertEquals("DDEV", server.getName());
+        Assert.assertEquals("test.ddev.site", server.getName());
         Assert.assertEquals("test.ddev.site", server.getHost());
 
         var mappings = server.getMappings();


### PR DESCRIPTION
This index allows to identify automatically generated configurations without the need of a naming pattern.
This adresses the problem of unnecessarily overwritten configurations and the need of the "DDEV" naming for generated configurations.
The pull request includes the migration of the PHP server configuration management to the new configuration management index.

## The Problem/Issue/Bug:
The ddev plugin references generated by configurations by their name "DDEV" this does not allow the name to change based on settings, as the relation would go lost. This is why the php server configuration could not be named by the fqdn till now.

## How this PR Solves the Problem:
This PR is changing the name of the generated php server configuration to the fqdn of the ddev project. This is made possible by the configuration management index.

## Manual Testing Instructions:

## Related Issue Link(s):
* https://github.com/php-perfect/ddev-intellij-plugin/issues/259
* https://github.com/php-perfect/ddev-intellij-plugin/issues/227