### PR TITLE
Fix mysql driver selection

### DIFF
--- a/src/main/java/de/php_perfect/intellij/ddev/database/DataSourceProviderImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/database/DataSourceProviderImpl.java
@@ -56,7 +56,7 @@ public final class DataSourceProviderImpl implements DataSourceProvider {
             case POSTGRESQL -> databaseDriverManager.getDriver("postgresql");
             case MARIADB -> databaseDriverManager.getDriver("mariadb");
             case MYSQL ->
-                    new ComparableVersion(version).compareTo(new ComparableVersion("8.0")) < 0 ? databaseDriverManager.getDriver("mysql") : databaseDriverManager.getDriver("mysql.8");
+                    new ComparableVersion(version).compareTo(new ComparableVersion("5.2")) < 0 ? databaseDriverManager.getDriver("mysql") : databaseDriverManager.getDriver("mysql.8");
         };
     }
 

--- a/src/test/java/de/php_perfect/intellij/ddev/database/DataSourceProviderTest.java
+++ b/src/test/java/de/php_perfect/intellij/ddev/database/DataSourceProviderTest.java
@@ -44,7 +44,7 @@ final class DataSourceProviderTest extends BasePlatformTestCase {
         Assertions.assertInstanceOf(LocalDataSource.class, dataSource);
         Assertions.assertNotNull(dataSource);
         Assertions.assertNotNull(dataSource.getDatabaseDriver());
-        Assertions.assertEquals("mysql", dataSource.getDatabaseDriver().getId());
+        Assertions.assertEquals("mysql.8", dataSource.getDatabaseDriver().getId());
         Assertions.assertEquals("jdbc:mysql://127.0.0.1:12345/db?user=some-user&password=some-password", dataSource.getUrl());
     }
 


### PR DESCRIPTION
## The Problem/Issue/Bug:
#278
## How this PR Solves the Problem:
- `mysql.8` driver is used for any MySQL database with version >= 5.2
## Manual Testing Instructions:
1. Create new ddev project with `ddev config --database mysql:5.7`
2. Run `ddev start`
3. Launch IntelliJ with updated plugin
4. Confirm no database errors are thrown and confirm "DDEV" data source is using the "MySQL supports since 5.2" driver
## Related Issue Link(s):
fixes #278 