### PR TITLE
Project name in env variable must be in lowercase

### DIFF
--- a/src/main/java/de/php_perfect/intellij/ddev/dockerCompose/DockerComposeCredentialProviderImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/dockerCompose/DockerComposeCredentialProviderImpl.java
@@ -27,7 +27,7 @@ public final class DockerComposeCredentialProviderImpl implements DockerComposeC
         credentials.setComposeFilePaths(dockerComposeConfig.composeFilePaths());
         credentials.setComposeServiceName(SERVICE_NAME);
         credentials.setRemoteProjectPath(DockerCredentialsEditor.DEFAULT_DOCKER_PROJECT_PATH);
-        credentials.setEnvs(EnvironmentVariablesData.create(Map.of(COMPOSE_PROJECT_NAME_ENV, "ddev-" + dockerComposeConfig.projectName()), true));
+        credentials.setEnvs(EnvironmentVariablesData.create(Map.of(COMPOSE_PROJECT_NAME_ENV, "ddev-" + dockerComposeConfig.projectName().toLowerCase()), true));
 
         return credentials;
     }


### PR DESCRIPTION
## The Problem/Issue/Bug:
Docker-compose doesn't supports upper case letters, so the existing container cannot be found.

## How this PR Solves the Problem:
The project name must be in lowercase even the project name itself contains uppercase letters.

## Manual Testing Instructions:
Create a ddev project with uppercase letters

## Related Issue Link(s):
https://discord.com/channels/664580571770388500/1239527694371131403/1239527694371131403