### PR TITLE
Fix redirect limit in update check

### DIFF
--- a/src/main/java/de/php_perfect/intellij/ddev/version/GithubClient.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/version/GithubClient.java
@@ -19,7 +19,7 @@ public final class GithubClient implements ReleaseClient {
 
     @Override
     public @Nullable LatestRelease loadCurrentVersion(@NotNull ProgressIndicator indicator) {
-        final RequestBuilder requestBuilder = HttpRequests.request(RELEASE_URL).accept("application/json").redirectLimit(1);
+        final RequestBuilder requestBuilder = HttpRequests.request(RELEASE_URL).accept("application/json").redirectLimit(2);
         indicator.checkCanceled();
 
         try {


### PR DESCRIPTION
## The Problem/Issue/Bug:
Resolves issue #326

## How this PR Solves the Problem:
redirectLimit has a misleading name, and actually requires a value of 1 + redirect limit.

See relevant HttpRequests code at https://github.com/JetBrains/intellij-community/blob/401226d2da0fff5e7996911fb2370cff7f66180a/platform/ide-core/src/com/intellij/util/io/HttpRequests.java#L552
and IntelliJ Community test suite at https://github.com/JetBrains/intellij-community/blob/451d49f1dde29a396096d1ed7c761c6afab62e68/platform/platform-tests/testSrc/com/intellij/util/io/HttpRequestsTest.kt#L89

## Manual Testing Instructions:
./gradlew build
Install resulting build/distributions/ddev-intellij-plugin-0.0.1-dev.zip
No more redirect exception on program start
