### PR TITLE
Change autoconfiguration of node.js binary path to node

### DIFF
--- a/src/main/java/de/php_perfect/intellij/ddev/node/AutoConfigureNodeInterpreterListener.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/node/AutoConfigureNodeInterpreterListener.java
@@ -33,7 +33,7 @@ public final class AutoConfigureNodeInterpreterListener implements DescriptionCh
             return;
         }
 
-        final NodeInterpreterConfig nodeInterpreterConfig = new NodeInterpreterConfig(description.getName(), composeFile.getPath(), "/usr/bin/node");
+        final NodeInterpreterConfig nodeInterpreterConfig = new NodeInterpreterConfig(description.getName(), composeFile.getPath(), "node");
         NodeInterpreterProvider.getInstance(this.project).configureNodeInterpreter(nodeInterpreterConfig);
     }
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:
The node.js binary path is incorrect for DDEV version 1.23.4, where the path changed from /usr/bin/node to /usr/local/bin/node.

## How this PR Solves the Problem:
This change sets the node binary without an absolute path. That way, functionality is ensured across DDEV versions without having to check the currently running version. This setup also matches the JetBrains documentation examples of setting up node.js docker compose remote interpreter.

## Manual Testing Instructions:
Remove the node.js DDEV connection
Close and reopen the project
Check the configuration, it should only refer to "node" as path
Test node functionality

## Related Issue Link(s):
#353 