### PR TITLE
Prevent ProgressIndicator warnings by using an EmptyProgressIndicator

### DIFF
--- a/src/main/java/de/php_perfect/intellij/ddev/cmd/ProcessExecutorImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/cmd/ProcessExecutorImpl.java
@@ -1,22 +1,37 @@
 package de.php_perfect.intellij.ddev.cmd;
 
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.CapturingProcessHandler;
 import com.intellij.execution.process.ProcessOutput;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.progress.EmptyProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
 import de.php_perfect.intellij.ddev.cmd.wsl.WslAware;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.atomic.AtomicReference;
 
 public class ProcessExecutorImpl implements ProcessExecutor {
     public static final Logger LOG = Logger.getInstance(ProcessExecutorImpl.class);
 
     public @NotNull ProcessOutput executeCommandLine(GeneralCommandLine commandLine, int timeout, boolean loginShell) throws ExecutionException {
-        commandLine = WslAware.patchCommandLine(commandLine, loginShell);
-        final CapturingProcessHandler processHandler = new CapturingProcessHandler(commandLine);
-        final ProcessOutput output = processHandler.runProcess(timeout);
-        LOG.debug("command: " + processHandler.getCommandLine() + " returned: " + output.toString());
+        final GeneralCommandLine patchedCommandLine = WslAware.patchCommandLine(commandLine, loginShell);
+        final AtomicReference<ProcessOutput> outputReference = new AtomicReference<>();
 
-        return output;
+        ProgressManager.getInstance().runProcess(() -> {
+            try {
+                CapturingProcessHandler processHandler = new CapturingProcessHandler(patchedCommandLine);
+                ProcessOutput output = processHandler.runProcess(timeout);
+                outputReference.set(output);
+
+                LOG.debug("command: " + processHandler.getCommandLine() + " returned: " + output);
+            } catch (ExecutionException e) {
+                throw new UncheckedExecutionException(e);
+            }
+        }, new EmptyProgressIndicator());
+
+        return outputReference.get();
     }
 }


### PR DESCRIPTION
## The Problem/Issue/Bug:
Resolve #313

## How this PR Solves the Problem:
By providing an EmptyProgressIndicator, functionality is maintained while satisfying the cause of the warning.
Maybe it can be solved more elegantly, but the current version is the most concise way I could find.
The chosen solution is marked as obsolete due to the strong suggestion by JetBrains to move to Kotlin.

## Manual Testing Instructions:
Open a Windows installation of an IDE and load a project stored on WSL.
Without the patch, warnings appear due to the background executions, with the patch, they no longer appear.

## Related Issue Link(s):
