### PR TITLE
Fix COMPOSE_PROJECT_NAME period issue #367

### DIFF
--- a/src/main/java/de/php_perfect/intellij/ddev/dockerCompose/DockerComposeCredentialProviderImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/dockerCompose/DockerComposeCredentialProviderImpl.java
@@ -27,7 +27,7 @@ public final class DockerComposeCredentialProviderImpl implements DockerComposeC
         credentials.setComposeFilePaths(dockerComposeConfig.composeFilePaths());
         credentials.setComposeServiceName(SERVICE_NAME);
         credentials.setRemoteProjectPath(DockerCredentialsEditor.DEFAULT_DOCKER_PROJECT_PATH);
-        credentials.setEnvs(EnvironmentVariablesData.create(Map.of(COMPOSE_PROJECT_NAME_ENV, "ddev-" + dockerComposeConfig.projectName().toLowerCase()), true));
+        credentials.setEnvs(EnvironmentVariablesData.create(Map.of(COMPOSE_PROJECT_NAME_ENV, "ddev-" + dockerComposeConfig.projectName().replace(".", "").toLowerCase()), true));
 
         return credentials;
     }


### PR DESCRIPTION
## The Problem/Issue/Bug:
Auto config breaks if project contains period . #367

## How this PR Solves the Problem:

## Manual Testing Instructions:

## Related Issue Link(s):
See https://github.com/php-perfect/ddev-intellij-plugin/issues/367#issuecomment-2393735285