### PR TITLE
Remove periods from COMPOSE_PROJECT_NAME

### DIFF
--- a/src/main/java/de/php_perfect/intellij/ddev/dockerCompose/DockerComposeCredentialProviderImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/dockerCompose/DockerComposeCredentialProviderImpl.java
@@ -27,7 +27,13 @@ public final class DockerComposeCredentialProviderImpl implements DockerComposeC
         credentials.setComposeFilePaths(dockerComposeConfig.composeFilePaths());
         credentials.setComposeServiceName(SERVICE_NAME);
         credentials.setRemoteProjectPath(DockerCredentialsEditor.DEFAULT_DOCKER_PROJECT_PATH);
-        credentials.setEnvs(EnvironmentVariablesData.create(Map.of(COMPOSE_PROJECT_NAME_ENV, "ddev-" + dockerComposeConfig.projectName().toLowerCase()), true));
+        credentials.setEnvs(EnvironmentVariablesData.create(
+                Map.of(
+                        COMPOSE_PROJECT_NAME_ENV,
+                        "ddev-" + dockerComposeConfig.projectName().toLowerCase().replace(".", "")
+                ),
+                true)
+        );
 
         return credentials;
     }


### PR DESCRIPTION
## The Problem/Issue/Bug:
#367 

## How this PR Solves the Problem:
Add replace call to remove all occurrences of periods during COMPOSE_PROJECT_NAME env assignment.

## Manual Testing Instructions:
Create a project with at least one period in the name
Run a CLI command using the DDEV container via the IDE

## Related Issue Link(s):
