### PR TITLE
Switch to URI where possible

### DIFF
--- a/src/main/java/de/php_perfect/intellij/ddev/actions/OpenServiceAction.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/actions/OpenServiceAction.java
@@ -12,22 +12,22 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
-import java.net.URL;
+import java.net.URI;
 import java.util.Objects;
 
 public final class OpenServiceAction extends DdevAwareAction {
 
-    private final @NotNull URL url;
+    private final @NotNull URI uri;
 
-    public OpenServiceAction(@NotNull URL url, @NotNull @NlsActions.ActionText String text,
+    public OpenServiceAction(@NotNull URI uri, @NotNull @NlsActions.ActionText String text,
                              @Nullable @NlsActions.ActionDescription String description, @Nullable Icon icon) {
         super(text, description, icon);
-        this.url = url;
+        this.uri = uri;
     }
 
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
-        BrowserUtil.browse(this.url);
+        BrowserUtil.browse(this.uri);
     }
 
     @Override
@@ -56,12 +56,12 @@ public final class OpenServiceAction extends DdevAwareAction {
             return false;
         }
         final OpenServiceAction that = (OpenServiceAction) o;
-        return Objects.equals(url, that.url);
+        return Objects.equals(uri, that.uri);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(url);
+        return Objects.hash(uri);
     }
 
     @Override

--- a/src/main/java/de/php_perfect/intellij/ddev/actions/ReportIssueAction.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/actions/ReportIssueAction.java
@@ -7,9 +7,6 @@ import com.intellij.openapi.project.DumbAwareAction;
 import de.php_perfect.intellij.ddev.DdevIntegrationBundle;
 import org.jetbrains.annotations.NotNull;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-
 public final class ReportIssueAction extends DumbAwareAction {
     private static final String NEW_ISSUE_URL = "https://github.com/php-perfect/ddev-intellij-plugin/issues/new?assignees=&labels=bug&template=bug_report.yml";
 
@@ -19,9 +16,6 @@ public final class ReportIssueAction extends DumbAwareAction {
 
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
-        try {
-            BrowserUtil.browse(new URI(NEW_ISSUE_URL));
-        } catch (URISyntaxException ignored) {
-        }
+        BrowserUtil.browse(NEW_ISSUE_URL);
     }
 }

--- a/src/main/java/de/php_perfect/intellij/ddev/php/server/ServerConfig.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/php/server/ServerConfig.java
@@ -7,18 +7,18 @@ import java.net.URI;
 import java.util.Objects;
 
 public record ServerConfig(@NotNull String localPath, @NotNull String remotePathPath,
-                           @NotNull URI url) implements IndexableConfiguration {
+                           @NotNull URI uri) implements IndexableConfiguration {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ServerConfig that = (ServerConfig) o;
-        return Objects.equals(localPath, that.localPath) && Objects.equals(remotePathPath, that.remotePathPath) && Objects.equals(url, that.url);
+        return Objects.equals(localPath, that.localPath) && Objects.equals(remotePathPath, that.remotePathPath) && Objects.equals(uri, that.uri);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(localPath, remotePathPath, url);
+        return Objects.hash(localPath, remotePathPath, uri);
     }
 
     @Override
@@ -26,7 +26,7 @@ public record ServerConfig(@NotNull String localPath, @NotNull String remotePath
         return "ServerConfig{" +
                 "localPath='" + localPath + '\'' +
                 ", remotePathPath='" + remotePathPath + '\'' +
-                ", url=" + url +
+                ", uri=" + uri +
                 '}';
     }
 }

--- a/src/main/java/de/php_perfect/intellij/ddev/php/server/ServerConfigManagerImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/php/server/ServerConfigManagerImpl.java
@@ -24,7 +24,7 @@ public final class ServerConfigManagerImpl implements ServerConfigManager {
 
     public void configure(final @NotNull ServerConfig serverConfig) {
         final int hash = serverConfig.hashCode();
-        final String fqdn = serverConfig.url().getHost();
+        final String fqdn = serverConfig.uri().getHost();
         final ManagedConfigurationIndex managedConfigurationIndex = ManagedConfigurationIndex.getInstance(this.project);
         final IndexEntry indexEntry = managedConfigurationIndex.get(ServerConfig.class);
         final List<PhpServer> servers = PhpServersWorkspaceStateComponent.getInstance(project).getServers();

--- a/src/main/java/de/php_perfect/intellij/ddev/tutorial/GotItTutorialImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/tutorial/GotItTutorialImpl.java
@@ -10,7 +10,6 @@ import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URISyntaxException;
 
 public final class GotItTutorialImpl implements GotItTutorial {
     private static final @NotNull Logger LOG = Logger.getInstance(GotItTutorialImpl.class);
@@ -23,9 +22,12 @@ public final class GotItTutorialImpl implements GotItTutorial {
             new GotItTooltip(ID_PREFIX + "status", DdevIntegrationBundle.message("tutorial.status.text"), disposable)
                     .withHeader(DdevIntegrationBundle.message("tutorial.status.title"))
                     .withIcon(DdevIntegrationIcons.DdevLogoColor)
-                    .withBrowserLink(DdevIntegrationBundle.message("tutorial.status.link"), new URI("https://github.com/php-perfect/ddev-intellij-plugin/wiki/Features#quick-access-to-ddev-services").toURL())
+                    .withBrowserLink(
+                            DdevIntegrationBundle.message("tutorial.status.link"),
+                            URI.create("https://github.com/php-perfect/ddev-intellij-plugin/wiki/Features#quick-access-to-ddev-services").toURL()
+                    )
                     .show(component, GotItTooltip.TOP_MIDDLE);
-        } catch (MalformedURLException | URISyntaxException e) {
+        } catch (MalformedURLException e) {
             LOG.error(e);
         }
     }
@@ -36,9 +38,12 @@ public final class GotItTutorialImpl implements GotItTutorial {
             new GotItTooltip(ID_PREFIX + "terminal", DdevIntegrationBundle.message("tutorial.terminal.text"), disposable)
                     .withHeader(DdevIntegrationBundle.message("tutorial.terminal.title"))
                     .withIcon(DdevIntegrationIcons.DdevLogoColor)
-                    .withBrowserLink(DdevIntegrationBundle.message("tutorial.terminal.link"), new URI("https://github.com/php-perfect/ddev-intellij-plugin/wiki/Features#integrated-ddev-terminal").toURL())
+                    .withBrowserLink(
+                            DdevIntegrationBundle.message("tutorial.terminal.link"),
+                            URI.create("https://github.com/php-perfect/ddev-intellij-plugin/wiki/Features#integrated-ddev-terminal").toURL()
+                    )
                     .show(component, GotItTooltip.BOTTOM_MIDDLE);
-        } catch (MalformedURLException | URISyntaxException e) {
+        } catch (MalformedURLException e) {
             LOG.error(e);
         }
     }

--- a/src/test/java/de/php_perfect/intellij/ddev/serviceActions/ServiceActionManagerImplTest.java
+++ b/src/test/java/de/php_perfect/intellij/ddev/serviceActions/ServiceActionManagerImplTest.java
@@ -11,8 +11,7 @@ import de.php_perfect.intellij.ddev.cmd.Service;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -55,12 +54,8 @@ final class ServiceActionManagerImplTest {
         ));
     }
 
-    private AnAction anAction(String displayText, String url, String description) {
-        try {
-            return new OpenServiceAction(new URL(url), displayText, description, AllIcons.General.Web);
-        } catch (MalformedURLException urlException) {
-            throw new RuntimeException(urlException);
-        }
+    private AnAction anAction(String displayText, String uri, String description) {
+        return new OpenServiceAction(URI.create(uri), displayText, description, AllIcons.General.Web);
     }
 
     private AnAction aMailhogAction() {


### PR DESCRIPTION
## The Problem/Issue/Bug:
Resolves #392 

## How this PR Solves the Problem:
Replace URL with URI where possible, implicitly fixing hashing and comparison collisions between URLs with different hostnames that resolve to the same IP address.

## Manual Testing Instructions:
- Set up a new DDEV project
- Add an additional service, e.g. `ddev add-on get ddev/ddev-solr`
- Configure the service to use the same ports as the web container (80 & 443), but with a different hostname:
```
VIRTUAL_HOST: solr.${DDEV_HOSTNAME}
HTTP_EXPOSE: 80:8983
HTTPS_EXPOSE: 443:8983
```
- `ddev start`
- The web and solr service names are no longer set to the same value, randomly changing, as displayed below:
![image](https://github.com/user-attachments/assets/8b7e351f-302c-478f-8617-032c77e8be03)
![image](https://github.com/user-attachments/assets/805df88e-89cf-4dee-a6e8-f86b8efea437)

## Related Issue Link(s):
