### PR TITLE
fix: sentry release failing due to shallow clone

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -65,6 +65,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Extract Tag Name
         uses: olegtarasov/get-tag@v2.1


### PR DESCRIPTION
## The Problem/Issue/Bug:

## How this PR Solves the Problem:

## Manual Testing Instructions:

## Related Issue Link(s):
