### PR TITLE
fix: add DB port check before updating connection URL (#513)

### DIFF
--- a/src/main/java/de/php_perfect/intellij/ddev/database/AutoConfigureDataSourceListener.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/database/AutoConfigureDataSourceListener.java
@@ -32,6 +32,10 @@ public final class AutoConfigureDataSourceListener implements DatabaseInfoChange
             return;
         }
 
+        if (databaseInfo.publishedPort() <= 0) {
+            return;
+        }
+
         if (PluginChecker.isMissingRequiredPlugins(this.project, FeatureRequiredPlugins.DATABASE, "database auto-registration")) {
             return;
         }


### PR DESCRIPTION
## The Problem/Issue/Bug:
DDEV outputs `"published_port":-1` for the database in `ddev describe -j`
The DB updating logic didn't validate the port number returned, leading to an invalid connection string of `jdbc:mariadb://127.0.0.1:-1/db?user=db&password=db`

## How this PR Solves the Problem:
Abort when the port number is <= 0

## Manual Testing Instructions:
Install [ddev-intellij-plugin-0.0.1-dev.zip](https://github.com/user-attachments/files/23487154/ddev-intellij-plugin-0.0.1-dev.zip)
- Existing project:
  - Open a project while DDEV is stopped
  - Check the DB connection URL of the DDEV entry
  - It should no longer be updated to a URL containing port -1
- New project:
  - Open a project while DDEV is stopped
  - No DB connection will be added
  - Run `ddev start` while the project is open
  - The DDEV DB connection will be automatically added when the project state switches to Running

## Related Issue Link(s):
* #513 