### PR TITLE
fix: catch UncheckedExecutionException on docker exec

### DIFF
--- a/src/main/java/de/php_perfect/intellij/ddev/cmd/DockerImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/cmd/DockerImpl.java
@@ -1,5 +1,6 @@
 package de.php_perfect.intellij.ddev.cmd;
 
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import org.jetbrains.annotations.NotNull;
@@ -14,7 +15,7 @@ public final class DockerImpl implements Docker {
                     5_000,
                     false
             ).getExitCode() == 0;
-        } catch (ExecutionException e) {
+        } catch (ExecutionException | UncheckedExecutionException e) {
             return false;
         }
     }
@@ -28,7 +29,7 @@ public final class DockerImpl implements Docker {
                     5_000,
                     false
             ).getStdout();
-        } catch (ExecutionException e) {
+        } catch (ExecutionException | UncheckedExecutionException e) {
             return "";
         }
     }


### PR DESCRIPTION
## The Problem/Issue/Bug:
See: https://php-perfect.sentry.io/issues/6547707863/
Currently, and UncheckedExecutionException is being thrown when the docker executable isn't found. This should instead be caught the same as other types of command execution exceptions.

## How this PR Solves the Problem:
Catch UncheckedExecutionException in DockerImpl

## Manual Testing Instructions:


## Related Issue Link(s):


**WIP**
Actually, this should either be using the remote settings to find the correct docker exec path, or not rely on docker itself anymore.