### PR TITLE
fix: move WSL commandline patching into runProcess

### DIFF
--- a/src/main/java/de/php_perfect/intellij/ddev/cmd/ProcessExecutorImpl.java
+++ b/src/main/java/de/php_perfect/intellij/ddev/cmd/ProcessExecutorImpl.java
@@ -1,6 +1,5 @@
 package de.php_perfect.intellij.ddev.cmd;
 
-import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.CapturingProcessHandler;
@@ -17,20 +16,25 @@ public class ProcessExecutorImpl implements ProcessExecutor {
     public static final Logger LOG = Logger.getInstance(ProcessExecutorImpl.class);
 
     public @NotNull ProcessOutput executeCommandLine(GeneralCommandLine commandLine, int timeout, boolean loginShell) throws ExecutionException {
-        final GeneralCommandLine patchedCommandLine = WslAware.patchCommandLine(commandLine, loginShell);
         final AtomicReference<ProcessOutput> outputReference = new AtomicReference<>();
+        final AtomicReference<ExecutionException> exceptionReference = new AtomicReference<>();
 
         ProgressManager.getInstance().runProcess(() -> {
             try {
+                final GeneralCommandLine patchedCommandLine = WslAware.patchCommandLine(commandLine, loginShell);
                 CapturingProcessHandler processHandler = new CapturingProcessHandler(patchedCommandLine);
                 ProcessOutput output = processHandler.runProcess(timeout);
                 outputReference.set(output);
 
                 LOG.debug("command: " + processHandler.getCommandLine() + " returned: " + output);
             } catch (ExecutionException e) {
-                throw new UncheckedExecutionException(e);
+                exceptionReference.set(e);
             }
         }, new EmptyProgressIndicator());
+
+        if (exceptionReference.get() != null) {
+            throw exceptionReference.get();
+        }
 
         return outputReference.get();
     }


### PR DESCRIPTION
## The Problem/Issue/Bug:

- #521 

Timing issue on Windows, when the project and Docker are on WSL, and the DDEV check command is started before a progress indicator has been created by another process

## How this PR Solves the Problem:

Move the commandline patching into the runProcess where we have a EmptyProgressIndicator created beforehand

## Manual Testing Instructions:

Install [ddev-intellij-plugin-0.0.1-dev.zip](https://github.com/user-attachments/files/24946415/ddev-intellij-plugin-0.0.1-dev.zip)

## Related Issue Link(s):
